### PR TITLE
Add patch method, update docs for criteria implementation

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -84,10 +84,10 @@ export class Rest {
   /**
    * Update a resource.
    *
-   * @param {string}        resource  Resource to update
-   * @param {string|Number} criteria  String / number of the id to update.
-   * @param {object}        body      New data for provided criteria.
-   * @param {{}}            [options]
+   * @param {string}           resource  Resource to update
+   * @param {{}|string|Number} criteria  Object for where clause, string / number for id.
+   * @param {object}           body      New data for provided criteria.
+   * @param {{}}               [options]
    *
    * @return {Promise}
    */
@@ -100,13 +100,33 @@ export class Rest {
 
     return this.request('put', requestPath, body, options);
   }
+  
+  /**
+   * Patch a resource.
+   *
+   * @param {string}           resource  Resource to patch
+   * @param {{}|string|Number} criteria  Object for where clause, string / number for id.
+   * @param {object}           body      Data to patch for provided criteria.
+   * @param {{}}               [options]
+   *
+   * @return {Promise}
+   */
+  patch(resource, criteria, body, options) {
+    let requestPath = resource;
+
+    if (criteria) {
+      requestPath += typeof criteria !== 'object' ? `/${criteria}` : '?' + qs.stringify(criteria);
+    }
+
+    return this.request('patch', requestPath, body, options);
+  }
 
   /**
    * Delete a resource.
    *
-   * @param {string}        resource  The resource to delete in
-   * @param {string|Number} criteria  String / number of the id to delete.
-   * @param {{}}            [options]
+   * @param {string}           resource  The resource to delete in
+   * @param {{}|string|Number} criteria  Object for where clause, string / number for id.
+   * @param {{}}               [options]
    *
    * @return {Promise}
    */


### PR DESCRIPTION
I felt an explicit patch method would complement the update method. I use both on an API endpoint. `PATCH` does a non-destructive update where `PUT` will set properties to undefined if they're absent. The difference is important when you don't wish to send the entire object back to the REST endpoint. 

I also updated the docs for the criteria. Since the implementation supports queries but the docs didn't state that.