### PR TITLE
Uppercase method

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -39,6 +39,9 @@ export class Rest {
 	// Force method to be upper-case for pre-flight Accept-Methods matching
 	requestOptions.method = requestOptions.toUpperCase();
 
+    // Force method to be upper-case for pre-flight Accept-Methods matching
+    requestOptions.method = requestOptions.toUpperCase();
+
     if (typeof body === 'object') {
       requestOptions.body = json(body);
     }

--- a/src/rest.js
+++ b/src/rest.js
@@ -35,6 +35,9 @@ export class Rest {
     if (typeof options !== 'undefined') {
       extend(true, requestOptions, options);
     }
+	
+	// Force method to be upper-case for pre-flight Accept-Methods matching
+	requestOptions.method = requestOptions.toUpperCase();
 
     if (typeof body === 'object') {
       requestOptions.body = json(body);


### PR DESCRIPTION
When doing pre-flight `OPTIONS` check on an API Endpoint, lowercase methods failed to match their uppercase representation. I've forced uppercase.