### PR TITLE
Prevent generating unnecessary imports in d.ts files.

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -27,9 +27,6 @@ gulp.task('build-dts', function() {
       return callback();
     }))
     .pipe(concat(jsName)) // concat all selected files to jsName (now without their imports)
-    .pipe(insert.transform(function(contents) { // re-add extracted imports on top
-      return tools.createImportBlock(importsToAdd) + contents;
-    }))
     .pipe(to5(assign({}, compilerOptions.dts()))); // compile to d.ts from file jsName. d.ts file is in folder paths.packageName
 });
 


### PR DESCRIPTION
This update will exclude all import statements when generating the d.ts files. This is to prevent the unnecessary dependency on external d.ts files to 3rd party libraries that may not used in the main project.