### PR TITLE
refactor: DI for Config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,17 @@
+import {inject, Factory} from 'aurelia-dependency-injection';
 import {HttpClient} from 'aurelia-fetch-client';
 import {Rest} from './rest';
 import extend from 'extend';
 
+@inject(Factory.of(HttpClient))
 export class Config {
   endpoints       = {};
   defaultEndpoint = null;
+  httpClientFactory = null;
 
+  constructor(httpClientFactory: Factory) {
+    this.httpClientFactory = httpClientFactory;
+  }
   /**
    * Register a new endpoint.
    *
@@ -17,7 +23,7 @@ export class Config {
    * @return {Config}
    */
   registerEndpoint(name, configureMethod, defaults = {}) {
-    let newClient        = new HttpClient();
+    let newClient        = this.httpClientFactory();
     this.endpoints[name] = new Rest(newClient, name);
 
     // add custom defaults to Rest

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,11 +1,14 @@
+import {Container} from 'aurelia-dependency-injection';
 import {HttpClient} from 'aurelia-fetch-client';
 import {Config, Rest} from '../src/aurelia-api';
 import extend from 'extend';
 
 describe('Config', function() {
+  let container = new Container();
+  container.registerTransient(Config);
   describe('.registerEndpoint()', function() {
     it('Should properly register an endpoint when providing a config callback.', function() {
-      let config   = new Config;
+      let config   = container.get(Config);
       let returned = config.registerEndpoint('github', function(configure) {
         configure.withBaseUrl(baseUrls.github);
         configure.withDefaults(userOptions);
@@ -17,7 +20,7 @@ describe('Config', function() {
     });
 
     it('Should properly register an endpoint when providing an endpoint string.', function() {
-      let config   = new Config;
+      let config   = container.get(Config);
       let returned = config.registerEndpoint('api', baseUrls.api);
 
       expect(config.endpoints.api.defaults).toEqual(defaultOptions);
@@ -26,7 +29,7 @@ describe('Config', function() {
     });
 
     it('Should properly register an endpoint with no arguments.', function() {
-      let config   = new Config;
+      let config   = container.get(Config);
       let returned = config.registerEndpoint('boring');
 
       expect(config.endpoints.boring.defaults).toEqual(defaultOptions);
@@ -35,7 +38,7 @@ describe('Config', function() {
     });
 
     it('Should properly register an endpoint when providing an endpoint string and defaults.', function() {
-      let config   = new Config;
+      let config   = container.get(Config);
       let returned = config.registerEndpoint('api', baseUrls.api, userOptions);
 
       expect(config.endpoints.api.defaults).toEqual(extend(true, {}, defaultOptions, userOptions));
@@ -46,7 +49,7 @@ describe('Config', function() {
 
   describe('.getEndpoint()', function() {
     it('Should return the registered endpoint, or null.', function() {
-      let config = new Config;
+      let config = container.get(Config);
 
       config.registerEndpoint('api', baseUrls.api);
 
@@ -72,7 +75,7 @@ describe('Config', function() {
 
   describe('.endpointExists()', function() {
     it('Should return if given name is a registered endpoint.', function() {
-      let config = new Config;
+      let config = container.get(Config);
 
       config.registerEndpoint('api', baseUrls.api);
 
@@ -84,7 +87,7 @@ describe('Config', function() {
 
   describe('.setDefaultEndpoint()', function() {
     it('Should set the default endpoint.', function() {
-      let config = new Config;
+      let config = container.get(Config);
 
       config.registerEndpoint('api', baseUrls.api);
       expect(config.getEndpoint()).toBe(null);


### PR DESCRIPTION
After some experiments i come with short conclusion.

Possible extention point:
For example we can add injection to Config:
`Optional.of('AureliaApi.IHttpClientFactory', true)`
where 'AureliaApi.IHttpClientFactory' - is the key of some custom factory that is registered in a root Container (on aurelia bootsrap). So we can use HttpClient factory by default, but if optional factory is specified we can use it instead default:
```

  constructor(httpClientFactory: Factory, customHttpClientFactory) {
    this.httpClientFactory = customHttpClientFactory || httpClientFactory;
  }
```

1) Why the key is so long and with prefix? - Because we register it in a root Container and we don't won't to have the same key as the other plugin or feature might have. Or we could use some abstract class or interface with "normal" name instead, but we have not got any.
2) What we can get from DI? https://github.com/SpoonX/aurelia-api/issues/54 - Not much right now. aurelia-fetch-client and aurelia-http-client doesn't implement same interface. It means that if we want to make user to use aurelia-http-client, we need to implement a wrapper (adapter) that implements the same interface as fetch HttpClient(because we use it as default).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/90)
<!-- Reviewable:end -->
