### PR TITLE
Client adapters

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -20,7 +20,7 @@ gulp.task('build-dts', function() {
   var importsToAdd = []; // stores extracted imports
 
   return gulp.src(paths.tsSource)
-    .pipe(tools.sortFiles())
+    //.pipe(tools.sortFiles())
     .pipe(through2.obj(function(file, enc, callback) {  // extract all imports to importsToAdd
       file.contents = new Buffer(tools.extractImports(file.contents.toString('utf8'), importsToAdd));
       this.push(file);
@@ -56,7 +56,7 @@ gulp.task('concat-modules', ['copy-resources'], function() {
   var importsToAdd = []; // stores extracted imports
 
   return gulp.src([paths.source, '!' + paths.root + paths.resources])
-    .pipe(tools.sortFiles())
+//    .pipe(tools.sortFiles())
     .pipe(through2.obj(function(file, enc, callback) {  // extract all imports to importsToAdd
       file.contents = new Buffer(tools.extractImports(file.contents.toString('utf8'), importsToAdd));
       this.push(file);

--- a/build/tasks/server.js
+++ b/build/tasks/server.js
@@ -22,6 +22,20 @@ app.post('/uploads', upload.single(), function(req, res) {
     });
 });
 
+app.set("jsonp callback name", "jsoncallback");
+
+app.get('/jsonp/*', function(req, res) {
+  res.jsonp({
+    path: req.path,
+    query: req.query,
+    body: req.body,
+    method: req.method,
+    contentType: req.header('content-type'),
+    Authorization: req.header('Authorization')
+  });
+
+});
+
 app.all('*', function(req, res) {
   res.send({
     path: req.path,

--- a/config.js
+++ b/config.js
@@ -9,9 +9,9 @@ System.config({
   map: {
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
     "aurelia-fetch-client": "npm:aurelia-fetch-client@1.0.0-beta.1.2.5",
-    "aurelia-http-client": "npm:aurelia-http-client@1.0.0-beta.1.2.1",
+    "aurelia-http-client": "npm:aurelia-http-client@1.0.0-beta.1.2.2",
     "aurelia-loader-default": "npm:aurelia-loader-default@1.0.0-beta.1.2.2",
-    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.1",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.2.0.1",
     "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.6",
     "extend": "npm:extend@3.0.0",
@@ -21,7 +21,7 @@ System.config({
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-http-client@1.0.0-beta.1.2.1": {
+    "npm:aurelia-http-client@1.0.0-beta.1.2.2": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
       "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2"
     },
@@ -37,7 +37,7 @@ System.config({
     "npm:aurelia-metadata@1.0.0-beta.1.2.1": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
-    "npm:aurelia-pal-browser@1.0.0-beta.1.2.1": {
+    "npm:aurelia-pal-browser@1.0.0-beta.2.0.1": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
     "npm:aurelia-polyfills@1.0.0-beta.1.1.6": {

--- a/config.js
+++ b/config.js
@@ -9,16 +9,35 @@ System.config({
   map: {
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3",
     "aurelia-fetch-client": "npm:aurelia-fetch-client@1.0.0-beta.1.2.5",
+    "aurelia-http-client": "npm:aurelia-http-client@1.0.0-beta.1.2.1",
+    "aurelia-loader-default": "npm:aurelia-loader-default@1.0.0-beta.1.2.2",
+    "aurelia-pal-browser": "npm:aurelia-pal-browser@1.0.0-beta.1.2.1",
+    "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0-beta.1.1.6",
     "extend": "npm:extend@3.0.0",
     "fetch": "github:github/fetch@1.0.0",
-    "qs": "npm:qs@6.2.0",
     "npm:aurelia-dependency-injection@1.0.0-beta.1.2.3": {
       "aurelia-logging": "npm:aurelia-logging@1.0.0-beta.1.2.1",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
+    "npm:aurelia-http-client@1.0.0-beta.1.2.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2"
+    },
+    "npm:aurelia-loader-default@1.0.0-beta.1.2.2": {
+      "aurelia-loader": "npm:aurelia-loader@1.0.0-beta.1.2.0",
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
+    },
+    "npm:aurelia-loader@1.0.0-beta.1.2.0": {
+      "aurelia-metadata": "npm:aurelia-metadata@1.0.0-beta.1.2.1",
+      "aurelia-path": "npm:aurelia-path@1.0.0-beta.1.2.2"
+    },
     "npm:aurelia-metadata@1.0.0-beta.1.2.1": {
+      "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
+    },
+    "npm:aurelia-pal-browser@1.0.0-beta.1.2.1": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0-beta.1.2.2"
     },
     "npm:aurelia-polyfills@1.0.0-beta.1.1.6": {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,7 +11,7 @@ module.exports = function (config) {
     jspm: {
       // Edit this to your needs
       loadFiles: ['test/setup.js', 'test/**/*.spec.js'],
-      serveFiles: ['src/**/*.js', 'test/resources/**/*.js'],
+      serveFiles: ['src/**/*.js', 'test/resources/**/*.js*'],
     },
 
     // list of files / patterns to load in the browser

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "jspm": {
     "registry": "npm",
-    "jspmPackage": true,
     "main": "aurelia-api",
     "format": "amd",
     "directories": {
@@ -33,15 +32,7 @@
     "dependencies": {
       "aurelia-dependency-injection": "^1.0.0-beta.1.2.3",
       "aurelia-fetch-client": "^1.0.0-beta.1.2.5",
-      "aurelia-http-client": "^1.0.0-beta.1.2.1",
-      "aurelia-loader-default": "^1.0.0-beta.1.2.2",
-      "aurelia-path": "^1.0.0-beta.1.2.2",
-      "extend": "^3.0.0"
-    },
-    "peerDependencies": {
-      "aurelia-dependency-injection": "^1.0.0-beta.1.2.3",
-      "aurelia-fetch-client": "^1.0.0-beta.1.2.5",
-      "aurelia-http-client": "^1.0.0-beta.1.2.1",
+      "aurelia-http-client": "^1.0.0-beta.1.2.2",
       "aurelia-loader-default": "^1.0.0-beta.1.2.2",
       "aurelia-path": "^1.0.0-beta.1.2.2",
       "extend": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -33,16 +33,21 @@
     "dependencies": {
       "aurelia-dependency-injection": "^1.0.0-beta.1.2.3",
       "aurelia-fetch-client": "^1.0.0-beta.1.2.5",
-      "extend": "^3.0.0",
-      "qs": "^6.1.0"
+      "aurelia-http-client": "^1.0.0-beta.1.2.1",
+      "aurelia-loader-default": "^1.0.0-beta.1.2.2",
+      "aurelia-path": "^1.0.0-beta.1.2.2",
+      "extend": "^3.0.0"
     },
     "peerDependencies": {
       "aurelia-dependency-injection": "^1.0.0-beta.1.2.3",
       "aurelia-fetch-client": "^1.0.0-beta.1.2.5",
-      "extend": "^3.0.0",
-      "qs": "^6.1.0"
+      "aurelia-http-client": "^1.0.0-beta.1.2.1",
+      "aurelia-loader-default": "^1.0.0-beta.1.2.2",
+      "aurelia-path": "^1.0.0-beta.1.2.2",
+      "extend": "^3.0.0"
     },
     "devDependencies": {
+      "aurelia-pal-browser": "^1.0.0-beta.1.2.1",
       "aurelia-polyfills": "^1.0.0-beta.1.1.6",
       "fetch": "github:github/fetch@^1.0.0"
     }
@@ -50,8 +55,10 @@
   "dependencies": {
     "aurelia-dependency-injection": "^1.0.0-beta.1.2.3",
     "aurelia-fetch-client": "^1.0.0-beta.1.2.5",
-    "extend": "^3.0.0",
-    "qs": "^6.1.0"
+    "aurelia-http-client": "^1.0.0-beta.1.2.1",
+    "aurelia-loader-default": "^1.0.0-beta.1.2.2",
+    "aurelia-path": "^1.0.0-beta.1.2.2",
+    "extend": "^3.0.0"
   },
   "devDependencies": {
     "aurelia-tools": "^0.1.20",

--- a/src/aurelia-api.js
+++ b/src/aurelia-api.js
@@ -1,6 +1,14 @@
 import {Config} from './config';
 import {Rest} from './rest';
 import {Endpoint} from './endpoint';
+import {ClientAdapter} from './client-adapters/client-adapter';
+import {FetchClientAdapter} from './client-adapters/fetch-client-adapter';
+import {HttpClientAdapter} from './client-adapters/http-client-adapter';
+import {JSONPClientAdapter} from './client-adapters/jsonp-client-adapter';
+import {StorageClientAdapter} from './client-adapters/storage-client-adapter';
+import {FileClientAdapter} from './client-adapters/file-client-adapter';
+import {StorageClient} from './client-adapters/storage-client';
+import {FileClient} from './client-adapters/file-client';
 
 function configure(aurelia, configCallback) {
   let config = aurelia.container.get(Config);
@@ -12,5 +20,13 @@ export {
   configure,
   Config,
   Rest,
-  Endpoint
+  Endpoint,
+  ClientAdapter,
+  FetchClientAdapter,
+  HttpClientAdapter,
+  JSONPClientAdapter,
+  StorageClientAdapter,
+  FileClientAdapter,
+  StorageClient,
+  FileClient
 };

--- a/src/client-adapters/client-adapter.js
+++ b/src/client-adapters/client-adapter.js
@@ -1,0 +1,48 @@
+/**
+* A generic client adapter, for wrapping clients service requests to a standard interface
+*/
+export class ClientAdapter {
+  /**
+   * Creates an instance of ClientAdapter.
+   *
+   * @param {any} client - required
+   */
+  constructor(client) {
+    if (!client) {
+      throw new TypeError('Contructor must provide a client to a client adapter');
+    }
+
+    if (typeof client.configure !== 'function') {
+      throw new TypeError('Client implementation must provide a configure function');
+    }
+
+    let hasWithBaseUrl = false;
+
+    client.configure(configure => {
+      if (!configure || typeof configure.withBaseUrl !== 'function') {
+        return;
+      }
+      hasWithBaseUrl = true;
+    });
+
+    if (!hasWithBaseUrl) {
+      throw new TypeError('Client configure function implementation must return an builder with a builder.withBaseUrl function');
+    }
+
+    this.client = client;
+  }
+
+  /**
+   * Make a request to the service.
+   *
+   * @param {string} method
+   * @param {string} path
+   * @param {{}}     [body]
+   * @param {{}}     [options]
+   *
+   * @return {Promise<Object|Error>}
+   */
+  request(method, path, body, optionsCopy) {
+    throw new TypeError('The client adapter must implement a request method.');
+  }
+}

--- a/src/client-adapters/client-adapter.js
+++ b/src/client-adapters/client-adapter.js
@@ -9,7 +9,7 @@ export class ClientAdapter {
    */
   constructor(client) {
     if (!client) {
-      throw new TypeError('Contructor must provide a client to a client adapter');
+      throw new TypeError('A client instance must get provided');
     }
 
     if (typeof client.configure !== 'function') {
@@ -26,7 +26,7 @@ export class ClientAdapter {
     });
 
     if (!hasWithBaseUrl) {
-      throw new TypeError('Client configure function implementation must return an builder with a builder.withBaseUrl function');
+      throw new TypeError('Client configure function implementation must return a builder with a builder.withBaseUrl function');
     }
 
     this.client = client;
@@ -45,4 +45,6 @@ export class ClientAdapter {
   request(method, path, body, optionsCopy) {
     throw new TypeError('The client adapter must implement a request method.');
   }
+
+  static Client;
 }

--- a/src/client-adapters/fetch-client-adapter.js
+++ b/src/client-adapters/fetch-client-adapter.js
@@ -1,0 +1,44 @@
+import {HttpClient as FetchClient} from 'aurelia-fetch-client';
+import {ClientAdapter} from './client-adapter';
+
+/**
+* A fetch client adapter for the aurelia-fetch-client
+*/
+export class FetchClientAdapter extends ClientAdapter {
+  /**
+   * Creates an instance of FetchClientAdapter.
+   *
+   * @param {HttpClient} httpClient from aurelia-fetch-client
+   */
+  constructor(client = new FetchClient()) {
+    super(client);
+  }
+
+  /**
+   * Make a request to the server.
+   *
+   * @param {string} method
+   * @param {string} path
+   * @param {{}}     [body]
+   * @param {{}}     [options]
+   *
+   * @return {Promise<Object|Error>}
+   */
+  request(method, path, body, options) {
+    let requestoptions = Object.assign({}, options);
+    requestoptions.method = method;
+
+    if (body !== undefined && body !== null && typeof body === 'object') {
+      requestoptions.body = JSON.stringify(body);
+      requestoptions.headers['Content-Type'] = 'application/json';
+    }
+
+    return this.client.fetch(path, requestoptions).then(response => {
+      if (response.status >= 200 && response.status < 400) {
+        return response.json().catch(error => null);
+      }
+
+      throw response;
+    });
+  }
+}

--- a/src/client-adapters/fetch-client-adapter.js
+++ b/src/client-adapters/fetch-client-adapter.js
@@ -22,7 +22,7 @@ export class FetchClientAdapter extends ClientAdapter {
    *
    * @param {HttpClient} httpClient from aurelia-fetch-client
    */
-  constructor(client = new FetchClient()) {
+  constructor(client = new FetchClientAdapter.Client) {
     super(client);
   }
 
@@ -55,4 +55,6 @@ export class FetchClientAdapter extends ClientAdapter {
       throw response;
     });
   }
+
+  static Client = FetchClient;
 }

--- a/src/client-adapters/fetch-client-adapter.js
+++ b/src/client-adapters/fetch-client-adapter.js
@@ -1,10 +1,22 @@
 import {HttpClient as FetchClient} from 'aurelia-fetch-client';
 import {ClientAdapter} from './client-adapter';
+import extend from 'extend';
 
 /**
 * A fetch client adapter for the aurelia-fetch-client
 */
 export class FetchClientAdapter extends ClientAdapter {
+  /**
+   * defaults for the fetch client
+   * @type {Object}
+   */
+  defaults = {
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    }
+  }
+
   /**
    * Creates an instance of FetchClientAdapter.
    *
@@ -25,15 +37,17 @@ export class FetchClientAdapter extends ClientAdapter {
    * @return {Promise<Object|Error>}
    */
   request(method, path, body, options) {
-    let requestoptions = Object.assign({}, options);
-    requestoptions.method = method;
+    let requestOptions = extend(true, {}, this.defaults, {method, body});
 
-    if (body !== undefined && body !== null && typeof body === 'object') {
-      requestoptions.body = JSON.stringify(body);
-      requestoptions.headers['Content-Type'] = 'application/json';
+    if (typeof body === 'object'
+    && !(typeof Blob === 'function' && body instanceof Blob)
+    && !(typeof FormData === 'function' && body instanceof FormData)) {
+      requestOptions.body = JSON.stringify(body);
     }
 
-    return this.client.fetch(path, requestoptions).then(response => {
+    extend(true, requestOptions, options);
+
+    return this.client.fetch(path, requestOptions).then(response => {
       if (response.status >= 200 && response.status < 400) {
         return response.json().catch(error => null);
       }

--- a/src/client-adapters/file-client-adapter.js
+++ b/src/client-adapters/file-client-adapter.js
@@ -10,7 +10,7 @@ export class FileClientAdapter extends ClientAdapter {
    *
    * @param {FileClient} fileClient
    */
-   constructor(client = new FileClient()) {
+   constructor(client = new FileClientAdapter.Client) {
      super(client);
    }
 
@@ -25,4 +25,6 @@ export class FileClientAdapter extends ClientAdapter {
   request(method, path) {
     return this.client.loadJson(path);
   }
+
+   static Client = FileClient;
 }

--- a/src/client-adapters/file-client-adapter.js
+++ b/src/client-adapters/file-client-adapter.js
@@ -1,0 +1,28 @@
+import {ClientAdapter} from './client-adapter';
+import {FileClient} from './file-client';
+
+/**
+* A file client adapter for the fetch-client
+*/
+export class FileClientAdapter extends ClientAdapter {
+  /**
+   * Creates an instance of FileClientAdapter.
+   *
+   * @param {FileClient} fileClient
+   */
+   constructor(client = new FileClient()) {
+     super(client);
+   }
+
+  /**
+   * Make a request to the file system.
+   *
+   * @param {string} method        -> not used, fixed to json/loadJson
+   * @param {string} path
+   *
+   * @return {Promise<Object|Error>}
+   */
+  request(method, path) {
+    return this.client.loadJson(path);
+  }
+}

--- a/src/client-adapters/file-client.js
+++ b/src/client-adapters/file-client.js
@@ -1,0 +1,67 @@
+import {parseQueryString, join} from 'aurelia-path';
+import {DefaultLoader} from 'aurelia-loader-default';
+import {findSelected} from './util';
+
+export class FileClient {
+  /**
+  * base path
+  */
+  baseUrl = '';
+
+  /**
+  * builder object
+  */
+  builder = {
+    withBaseUrl: baseUrl => {
+      this.baseUrl = baseUrl;
+      return baseUrl;
+    },
+    withLoader: loader => this.loader = loader
+  };
+
+  /**
+  * Creates an instance of FileClient.
+   *
+   * @param {loader} File loader with loader.loadText(path). default: (aurelia-)DefaultLoader
+   */
+  constructor(loader = new DefaultLoader()) {
+    this.loader = loader;
+  }
+
+  /**
+  * Configure this client with default settings to be used by all requests.
+  *
+  * @param config A configuration object, or a function that takes a config
+  * object and configures it.
+  * @returns The chainable instance of this FileClient.
+  * @chainable
+  */
+   configure(_configure) {
+    if (typeof _configure === 'function') {
+      _configure(this.builder);
+    } else if (typeof _configure === 'string') {
+      this.baseUrl = _configure;
+    }
+
+    return this;
+  }
+
+  /**
+  * Fetches a resource. Default configuration parameters
+  * will be applied.
+  *
+  * @param path A string containing the URL of the resource.
+  * @returns A Promise<Object|Error> with the response
+  */
+  loadJson(path) {
+    let [, pathKey, , id, , query] = /^([^\/^\?]+)(\/)?([^\/^\?]+)?(\?)?(.+)?/.exec(path);
+
+    let queryParameters = parseQueryString(query);
+    if (id) queryParameters.id = id;
+
+    return this.loader.loadText(join(this.baseUrl, pathKey) + '.json').then(text => {
+      let resource = JSON.parse(text);
+      return findSelected(resource, queryParameters) || [];
+    });
+  }
+}

--- a/src/client-adapters/file-client.js
+++ b/src/client-adapters/file-client.js
@@ -4,12 +4,14 @@ import {findSelected} from './util';
 
 export class FileClient {
   /**
-  * base path
+  *  base path
+  *  @type {String}
   */
   baseUrl = '';
 
   /**
-  * builder object
+  *  builder object
+  *  @type {Object}
   */
   builder = {
     withBaseUrl: baseUrl => {

--- a/src/client-adapters/file-client.js
+++ b/src/client-adapters/file-client.js
@@ -36,7 +36,7 @@ export class FileClient {
   * @returns The chainable instance of this FileClient.
   * @chainable
   */
-   configure(_configure) {
+  configure(_configure) {
     if (typeof _configure === 'function') {
       _configure(this.builder);
     } else if (typeof _configure === 'string') {

--- a/src/client-adapters/file-client.js
+++ b/src/client-adapters/file-client.js
@@ -10,7 +10,7 @@ export class FileClient {
   baseUrl = '';
 
   /**
-  *  builder object
+  *  The builder with builder.withBaseUrl() for the use in configure
   *  @type {Object}
   */
   builder = {
@@ -23,9 +23,9 @@ export class FileClient {
 
   /**
   * Creates an instance of FileClient.
-   *
-   * @param {loader} File loader with loader.loadText(path). default: (aurelia-)DefaultLoader
-   */
+  *
+  * @param {function} File loader with loader.loadText(path). default: (aurelia-)DefaultLoader
+  */
   constructor(loader = new DefaultLoader()) {
     this.loader = loader;
   }

--- a/src/client-adapters/http-client-adapter.js
+++ b/src/client-adapters/http-client-adapter.js
@@ -1,0 +1,46 @@
+import {HttpClient, HttpRequestMessage, Headers} from 'aurelia-http-client';
+import {ClientAdapter} from './client-adapter';
+
+/**
+* A http client adapter for the aurelia-http-client
+*/
+export class HttpClientAdapter extends ClientAdapter {
+  /**
+   * Creates an instance of HttphClientAdapter.
+   *
+   * @param {HttpClient} httpClient from aurelia-http-client
+   */
+  constructor(client = new HttpClient()) {
+    super(client);
+  }
+
+  /**
+   * Make a request to the server.
+   *
+   * @param {string} method
+   * @param {string} path
+   * @param {{}}     [body]
+   * @param {{}}     [options]
+   *
+   * @return {Promise<Object|Error>}
+   */
+  request(method, path, body, options) {
+    let requestoptions = Object.assign({}, options);
+
+    if (typeof body === 'object') {
+      requestoptions.body = JSON.stringify(body);
+      requestoptions.headers['Content-Type'] = 'application/json';
+    }
+
+    let msg = new HttpRequestMessage(method, path, body, new Headers(requestoptions.headers));
+
+    return this.client.send(msg)
+      .then(response => {
+        if (response.statusCode >= 200 && response.statusCode < 400) {
+          return JSON.parse(response.response);
+        }
+
+        throw response;
+      });
+  }
+}

--- a/src/client-adapters/http-client-adapter.js
+++ b/src/client-adapters/http-client-adapter.js
@@ -1,10 +1,22 @@
 import {HttpClient, HttpRequestMessage, Headers} from 'aurelia-http-client';
 import {ClientAdapter} from './client-adapter';
+import extend from 'extend';
 
 /**
 * A http client adapter for the aurelia-http-client
 */
 export class HttpClientAdapter extends ClientAdapter {
+  /**
+   * defaults for the http client
+   * @type {Object}
+   */
+  defaults = {
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    }
+  }
+
   /**
    * Creates an instance of HttphClientAdapter.
    *
@@ -25,14 +37,17 @@ export class HttpClientAdapter extends ClientAdapter {
    * @return {Promise<Object|Error>}
    */
   request(method, path, body, options) {
-    let requestoptions = Object.assign({}, options);
+    let requestOptions = extend(true, {}, this.defaults, {method, body});
 
-    if (typeof body === 'object') {
-      requestoptions.body = JSON.stringify(body);
-      requestoptions.headers['Content-Type'] = 'application/json';
+    if (typeof body === 'object'
+    && !(typeof Blob === 'function' && body instanceof Blob)
+    && !(typeof FormData === 'function' && body instanceof FormData)) {
+      requestOptions.body = JSON.stringify(body);
     }
 
-    let msg = new HttpRequestMessage(method, path, body, new Headers(requestoptions.headers));
+    extend(true, requestOptions, options);
+
+    let msg = new HttpRequestMessage(method, path, body, new Headers(requestOptions.headers));
 
     return this.client.send(msg)
       .then(response => {

--- a/src/client-adapters/http-client-adapter.js
+++ b/src/client-adapters/http-client-adapter.js
@@ -22,7 +22,7 @@ export class HttpClientAdapter extends ClientAdapter {
    *
    * @param {HttpClient} httpClient from aurelia-http-client
    */
-  constructor(client = new HttpClient()) {
+  constructor(client = new HttpClientAdapter.Client) {
     super(client);
   }
 
@@ -58,4 +58,6 @@ export class HttpClientAdapter extends ClientAdapter {
         throw response;
       });
   }
+
+  static Client = HttpClient;
 }

--- a/src/client-adapters/jsonp-client-adapter.js
+++ b/src/client-adapters/jsonp-client-adapter.js
@@ -6,14 +6,15 @@ import {ClientAdapter} from './client-adapter';
 */
 export class JSONPClientAdapter extends ClientAdapter {
   /**
-   * Optional default callbackParameterName
+   *  Optional default callbackParameterName
+   *  @type {String}
   */
   callbackParameterName;
 
   /**
-   * Creates an instance of JSONPClientAdapter.
+   *  Creates an instance of JSONPClientAdapter.
    *
-   * @param {HttpClient} httpClient from aurelia-http-client
+   *  @param {HttpClient} httpClient from aurelia-http-client
    */
   constructor(client = new HttpClient()) {
     super(client);

--- a/src/client-adapters/jsonp-client-adapter.js
+++ b/src/client-adapters/jsonp-client-adapter.js
@@ -16,7 +16,7 @@ export class JSONPClientAdapter extends ClientAdapter {
    *
    *  @param {HttpClient} httpClient from aurelia-http-client
    */
-  constructor(client = new HttpClient()) {
+  constructor(client = new JSONPClientAdapter.Client) {
     super(client);
   }
 
@@ -44,4 +44,6 @@ export class JSONPClientAdapter extends ClientAdapter {
         throw response;
       });
   }
+
+  static Client = HttpClient;
 }

--- a/src/client-adapters/jsonp-client-adapter.js
+++ b/src/client-adapters/jsonp-client-adapter.js
@@ -1,0 +1,46 @@
+import {HttpClient} from 'aurelia-http-client';
+import {ClientAdapter} from './client-adapter';
+
+/**
+* A jsonp client adapter for the aurelia-http-client
+*/
+export class JSONPClientAdapter extends ClientAdapter {
+  /**
+   * Optional default callbackParameterName
+  */
+  callbackParameterName;
+
+  /**
+   * Creates an instance of JSONPClientAdapter.
+   *
+   * @param {HttpClient} httpClient from aurelia-http-client
+   */
+  constructor(client = new HttpClient()) {
+    super(client);
+  }
+
+  /**
+   * Make a request to the server.
+   *
+   * @param {string} method, not used fixed to JSONP get
+   * @param {string} path
+   * @param {{}}     [body], not used
+   * @param {{}}     [options] only callbackParameterName is used
+   *
+   * @return {Promise<Object|Error>}
+   */
+  request(method, path, body, options = {}) {
+    let callbackParameterName = options.callbackParameterName
+                              ? options.callbackParameterName
+                              : this.callbackParameterName;
+
+    return this.client.jsonp(path, callbackParameterName)
+      .then(response => {
+        if (response.statusCode >= 200 && response.statusCode < 400) {
+          return response.response;
+        }
+
+        throw response;
+      });
+  }
+}

--- a/src/client-adapters/storage-client-adapter.js
+++ b/src/client-adapters/storage-client-adapter.js
@@ -1,0 +1,29 @@
+import {ClientAdapter} from './client-adapter';
+import {StorageClient} from './storage-client';
+
+/**
+* A storage client adapter for the storage-client
+*/
+export class StorageClientAdapter extends ClientAdapter {
+  /**
+  * Creates an instance of StorageClientAdapter.
+   *
+   * @param {StorageClient} StorageClient
+   */
+  constructor(client = new StorageClient()) {
+    super(client);
+  }
+
+  /**
+   * Make a request to the storage.
+   *
+   * @param {string} method
+   * @param {string} path
+   * @param {{}}     [body]
+   *
+   * @return {Promise<Object|Error>}
+   */
+  request(method, path, body) {
+    return this.client.send(...arguments);
+  }
+}

--- a/src/client-adapters/storage-client-adapter.js
+++ b/src/client-adapters/storage-client-adapter.js
@@ -10,7 +10,7 @@ export class StorageClientAdapter extends ClientAdapter {
    *
    * @param {StorageClient} StorageClient
    */
-  constructor(client = new StorageClient()) {
+  constructor(client = new StorageClientAdapter.Client) {
     super(client);
   }
 
@@ -26,4 +26,6 @@ export class StorageClientAdapter extends ClientAdapter {
   request(method, path, body) {
     return this.client.send(...arguments);
   }
+
+  static Client = StorageClient;
 }

--- a/src/client-adapters/storage-client.js
+++ b/src/client-adapters/storage-client.js
@@ -3,7 +3,8 @@ import extend from 'extend';
 import {findSelected} from './util';
 
 /**
-* the key base for all storage keys
+*  the key base for all storage keys
+*  @type {String}
 */
 const baseStorageKey = 'AureliaStorageClient';
 
@@ -12,12 +13,14 @@ const baseStorageKey = 'AureliaStorageClient';
 */
 export class StorageClient {
   /**
-  * additional base for the storgae key
+  *  additional base for the storgae key
+  *  @type {String}
   */
   baseUrl = '';
 
   /**
-  * builder object
+  *  builder object
+  *  @type {Object}
   */
   builder = {
     withBaseUrl: baseUrl => {

--- a/src/client-adapters/storage-client.js
+++ b/src/client-adapters/storage-client.js
@@ -62,7 +62,7 @@ export class StorageClient {
   * @param [Body] The body to send (optional)
   * @returns A Promise<Object|Error> with the response
   */
-   send(method, path, body) {
+  send(method, path, body) {
     let [, pathKey, , id, , query] = /^([^\/^\?]+)(\/)?([^\/^\?]+)?(\?)?(.+)?/.exec(path);
     let key = `${this.getStorageKey()}${pathKey}`;
     let queryParameters = parseQueryString(query);

--- a/src/client-adapters/storage-client.js
+++ b/src/client-adapters/storage-client.js
@@ -34,7 +34,7 @@ export class StorageClient {
    *
    * @param {storage} localStorage (default), sessionStore or any other interface compliant storage
    */
-  constructor(storage = window.localStorage) {
+  constructor(storage = localStorage) {
     this.storage = storage;
   }
 

--- a/src/client-adapters/storage-client.js
+++ b/src/client-adapters/storage-client.js
@@ -1,0 +1,171 @@
+import {parseQueryString} from 'aurelia-path';
+import extend from 'extend';
+import {findSelected} from './util';
+
+/**
+* the key base for all storage keys
+*/
+const baseStorageKey = 'AureliaStorageClient';
+
+/**
+* A client for browser storage
+*/
+export class StorageClient {
+  /**
+  * additional base for the storgae key
+  */
+  baseUrl = '';
+
+  /**
+  * builder object
+  */
+  builder = {
+    withBaseUrl: baseUrl => {
+      this.baseUrl = baseUrl;
+      return baseUrl;
+    }
+  };
+
+  /**
+  * Creates an instance of StorageClient.
+   *
+   * @param {storage} localStorage (default), sessionStore or any other interface compliant storage
+   */
+  constructor(storage = window.localStorage) {
+    this.storage = storage;
+  }
+
+  /**
+  * Configure this client with default settings to be used by all requests.
+  *
+  * @param config A configuration object, or a function that takes a config
+  * object and configures it.
+  * @returns The chainable instance of this StorageClient.
+  * @chainable
+  */
+  configure(_configure) {
+    if (typeof _configure === 'function') {
+      _configure(this.builder);
+    } else if (typeof _configure === 'string') {
+      this.baseUrl = _configure;
+    }
+
+    return this;
+  }
+
+  /**
+  * Fetches a resource. Default configuration parameters
+  * will be applied.
+  *
+  * @param method The method to apply (GET, PUT, PATCH, POST, DELETE)
+  * @param path A string containing the URL of the resource.
+  * @param [Body] The body to send (optional)
+  * @returns A Promise<Object|Error> with the response
+  */
+   send(method, path, body) {
+    let [, pathKey, , id, , query] = /^([^\/^\?]+)(\/)?([^\/^\?]+)?(\?)?(.+)?/.exec(path);
+    let key = `${this.getStorageKey()}${pathKey}`;
+    let queryParameters = parseQueryString(query);
+    if (id) queryParameters.id = id;
+
+    let resource = JSON.parse(this.storage.getItem(key));
+    let selection = findSelected(resource, queryParameters) || [];
+
+    return new Promise(resolve => {
+      switch (method.toUpperCase()) {
+      case 'GET': {
+        resolve(selection.length === 1 ? selection[0] : selection);
+        break;
+      }
+      case 'POST': {
+        let addition = Array.isArray(body) ? body : [body];
+
+        addition.forEach(el => {
+          el.id = resource[resource.length - 1].id + 1;
+          resource.push(el);
+        });
+
+        this.storage.setItem(key, JSON.stringify(resource));
+
+        resolve(body);
+        break;
+      }
+      case 'PUT': {
+        let replacedSelection = selection.map(el => el = Object.assign({id: el.id}, body));
+
+        let newResource = resource.map(el => {
+          let index = replacedSelection.findIndex(_el => el.id === _el.id);
+          return (index !== -1) ? el = replacedSelection[index] : el;
+        });
+
+        this.storage.setItem(key, JSON.stringify(newResource));
+
+        resolve(replacedSelection);
+        break;
+      }
+      case 'PATCH': {
+        let patchedSelection = selection.map(el => extend(true, el, body));
+
+        let newResource = resource.map(el => {
+          let index = patchedSelection.findIndex(_el => el.id === _el.id);
+          return (index !== -1) ? el = patchedSelection[index] : el;
+        });
+
+        this.storage.setItem(key, JSON.stringify(newResource));
+
+        resolve(patchedSelection);
+        break;
+      }
+      case 'DELETE': {
+        if (Object.keys(queryParameters).length === 0) {
+          this.storage.removeItem(key);
+
+          resolve(resource);
+          break;
+        }
+
+        let newResource = [];
+        resource.forEach(el => {
+          let index = selection.findIndex(_el => el.id === _el.id);
+          if (index === -1) newResource.push(el);
+        });
+
+        this.storage.setItem(key, JSON.stringify(newResource));
+
+        resolve(selection);
+        break;
+      }
+      default:
+        console.info(`Unknown method ${method}`);
+      }
+    });
+  }
+
+  /**
+  * Clears the storage of all items of the baseUrl key
+  */
+  clear() {
+    this.storage.removeItem(this.getStorageKey());
+  }
+
+  /**
+  * Clears the storage of all items of all storage clients
+  */
+  static clear(storage) {
+    const reg = /^`${baseStorageKey}`-.+/;
+    for (let i = 0; i < storage.length; i++) {
+      if (reg.test(storage.key(i))) {
+        storage.removeItem(storage.key(i));
+      }
+    }
+  }
+
+  /**
+  * Gets the full key for this baseUrl key.
+  *
+  * @returns The key
+  */
+  getStorageKey() {
+    return `${baseStorageKey}-${this.baseUrl}`;
+  }
+}

--- a/src/client-adapters/storage-client.js
+++ b/src/client-adapters/storage-client.js
@@ -19,7 +19,7 @@ export class StorageClient {
   baseUrl = '';
 
   /**
-  *  builder object
+  *  The builder with builder.withBaseUrl() for the use in configure
   *  @type {Object}
   */
   builder = {

--- a/src/client-adapters/util.js
+++ b/src/client-adapters/util.js
@@ -1,0 +1,26 @@
+/**
+* Find all pojos with criteria in an array of pojos
+*
+* @param resource The array of objects to search
+* @param queryParameters The query object with the criteria
+*
+* @returns An array of the objects in the resource which match the queryParameters
+*/
+export function findSelected(resource, queryParameters) {
+  if (Object.keys(queryParameters).length === 0) return resource;
+
+  let selection = [];
+
+  resource.map(el => {
+    let matches = true;
+    for (let key in queryParameters) {
+      if (el[key] === undefined || queryParameters[key] !== el[key].toString()) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches) selection.push(el);
+  });
+
+  return selection;
+}

--- a/src/config.js
+++ b/src/config.js
@@ -7,27 +7,32 @@ import {Rest} from './rest';
  */
 export class Config {
   /**
-   * Collection of configures endpionts
-   * @type {Object} Key: endpoint name, value: Rest client
+   * GOJO of registered endpoint names and Rest clients
+   * @type {Object}
    */
-  endpoints       = {};
+  endpoints = {};
 
   /**
    * Current default endpoint if set
    * @type {[Rest]} Default Rest client
    */
   defaultEndpoint = null;
-  defaultClientAdapter = FetchClientAdapter;
+
+  /**
+  * The default client adpater class
+  *  @type {function}
+  */
+  DefaultClientAdapter;
 
   /**
    * Set a new defaultClientAdapter
    *
-   * @param {class}  clientAdapter  The ClientAdapter class
+   * @param {function}  ClientAdapter  A ClientAdapter class (default: FetchClientAdapter)
    *
    * @return {Config}
    */
-  setDefaultClientAdapter(clientAdapter) {
-    this.defaultClientAdapter = clientAdapter;
+  setDefaultClientAdapter(ClientAdapter = FetchClientAdapter) {
+    this.DefaultClientAdapter = ClientAdapter;
 
     return this;
   }
@@ -38,11 +43,12 @@ export class Config {
    * @type {string}          name              The name of the new endpoint.
    * @type {function|string} [configureMethod] Configure method or endpoint.
    * @type {{}}              [defaults]        New defaults for the HttpClient
+   * @param {[function]}     [SelectedClientAdapter]  ClientAdapter class for this endpoint [default: DefaultClientAdapter]
    *
    * @see http://aurelia.io/docs.html#/aurelia/fetch-client/latest/doc/api/class/HttpClientConfiguration
    * @return {Config}
    */
-  registerEndpoint(name, configureMethod, defaults = {}, SelectedClientAdapter = this.defaultClientAdapter) {
+  registerEndpoint(name, configureMethod, defaults = {}, SelectedClientAdapter = this.DefaultClientAdapter) {
     let clientAdapter    = new SelectedClientAdapter();
     if (!(clientAdapter instanceof ClientAdapter)) throw new TypeError('clientAdapter not of type ClientAdapter');
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 import {ClientAdapter} from './client-adapters/client-adapter';
 import {FetchClientAdapter} from './client-adapters/fetch-client-adapter';
 import {Rest} from './rest';
+import extend from 'extend';
 
 /**
  * Config class. Configures and stores endpoints

--- a/src/config.js
+++ b/src/config.js
@@ -48,8 +48,8 @@ export class Config {
 
     this.endpoints[name] = new Rest(clientAdapter, name);
 
-    // set custom defaults to Rest
-    if (defaults !== undefined) this.endpoints[name].defaults = defaults;
+    // add custom defaults to clientAdapter
+    clientAdapter.defaults = extend(true, {}, clientAdapter.defaults || {}, defaults);
 
     // Manual configure of client.
     if (typeof configureMethod === 'function') {

--- a/src/config.js
+++ b/src/config.js
@@ -22,7 +22,7 @@ export class Config {
   * The default client adpater class
   *  @type {function}
   */
-  DefaultClientAdapter;
+  DefaultClientAdapter = FetchClientAdapter;
 
   /**
    * Set a new defaultClientAdapter
@@ -31,8 +31,8 @@ export class Config {
    *
    * @return {Config}
    */
-  setDefaultClientAdapter(ClientAdapter = FetchClientAdapter) {
-    this.DefaultClientAdapter = ClientAdapter;
+  setDefaultClientAdapter(DefaultClientAdapter) {
+    this.DefaultClientAdapter = DefaultClientAdapter;
 
     return this;
   }

--- a/src/config.js
+++ b/src/config.js
@@ -48,8 +48,7 @@ export class Config {
    * @see http://aurelia.io/docs.html#/aurelia/fetch-client/latest/doc/api/class/HttpClientConfiguration
    * @return {Config}
    */
-  registerEndpoint(name, configureMethod, defaults = {}, SelectedClientAdapter = this.DefaultClientAdapter) {
-    let clientAdapter    = new SelectedClientAdapter();
+  registerEndpoint(name, configureMethod, defaults = {}, clientAdapter = new this.DefaultClientAdapter(new this.DefaultClientAdapter.Client)) {
     if (!(clientAdapter instanceof ClientAdapter)) throw new TypeError('clientAdapter not of type ClientAdapter');
 
     this.endpoints[name] = new Rest(clientAdapter, name);

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,5 @@
-import {HttpClient} from 'aurelia-fetch-client';
+import {ClientAdapter} from './client-adapters/client-adapter';
+import {FetchClientAdapter} from './client-adapters/fetch-client-adapter';
 import {Rest} from './rest';
 
 /**
@@ -16,6 +17,20 @@ export class Config {
    * @type {[Rest]} Default Rest client
    */
   defaultEndpoint = null;
+  defaultClientAdapter = FetchClientAdapter;
+
+  /**
+   * Set a new defaultClientAdapter
+   *
+   * @param {class}  clientAdapter  The ClientAdapter class
+   *
+   * @return {Config}
+   */
+  setDefaultClientAdapter(clientAdapter) {
+    this.defaultClientAdapter = clientAdapter;
+
+    return this;
+  }
 
   /**
    * Register a new endpoint.
@@ -27,16 +42,18 @@ export class Config {
    * @see http://aurelia.io/docs.html#/aurelia/fetch-client/latest/doc/api/class/HttpClientConfiguration
    * @return {Config}
    */
-  registerEndpoint(name, configureMethod, defaults) {
-    let newClient        = new HttpClient();
-    this.endpoints[name] = new Rest(newClient, name);
+  registerEndpoint(name, configureMethod, defaults = {}, SelectedClientAdapter = this.defaultClientAdapter) {
+    let clientAdapter    = new SelectedClientAdapter();
+    if (!(clientAdapter instanceof ClientAdapter)) throw new TypeError('clientAdapter not of type ClientAdapter');
+
+    this.endpoints[name] = new Rest(clientAdapter, name);
 
     // set custom defaults to Rest
     if (defaults !== undefined) this.endpoints[name].defaults = defaults;
 
     // Manual configure of client.
     if (typeof configureMethod === 'function') {
-      newClient.configure(configureMethod);
+      clientAdapter.client.configure(configureMethod);
 
       return this;
     }
@@ -47,7 +64,7 @@ export class Config {
     }
 
     // Base url is string. Configure.
-    newClient.configure(configure => {
+    clientAdapter.client.configure(configure => {
       configure.withBaseUrl(configureMethod);
     });
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,16 +1,28 @@
 import {HttpClient} from 'aurelia-fetch-client';
 import {Rest} from './rest';
 
+/**
+ * Config class. Configures and stores endpoints
+ */
 export class Config {
+  /**
+   * Collection of configures endpionts
+   * @type {Object} Key: endpoint name, value: Rest client
+   */
   endpoints       = {};
+
+  /**
+   * Current default endpoint if set
+   * @type {[Rest]} Default Rest client
+   */
   defaultEndpoint = null;
 
   /**
    * Register a new endpoint.
    *
-   * @param {string}          name              The name of the new endpoint.
-   * @param {function|string} [configureMethod] Configure method or endpoint.
-   * @param {{}}              [defaults]        New defaults for the HttpClient
+   * @type {string}          name              The name of the new endpoint.
+   * @type {function|string} [configureMethod] Configure method or endpoint.
+   * @type {{}}              [defaults]        New defaults for the HttpClient
    *
    * @see http://aurelia.io/docs.html#/aurelia/fetch-client/latest/doc/api/class/HttpClientConfiguration
    * @return {Config}
@@ -45,7 +57,7 @@ export class Config {
   /**
    * Get a previously registered endpoint. Returns null when not found.
    *
-   * @param {string} [name] Returns default endpoint when not set.
+   * @type {string} [name] Endpoint bame. Returns default endpoint when not set.
    *
    * @return {Rest|null}
    */
@@ -60,7 +72,7 @@ export class Config {
   /**
    * Check if an endpoint has been registered.
    *
-   * @param {string} name
+   * @type {string} name The endpoint name
    *
    * @return {boolean}
    */
@@ -71,7 +83,7 @@ export class Config {
   /**
    * Set a previously registered endpoint as the default.
    *
-   * @param {string} name
+   * @type {string} name The endpoint name
    *
    * @return {Config}
    */

--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -12,9 +12,8 @@ export class Endpoint {
    *
    * @type {string} key
    */
-  constructor(key, ...rest) {
+  constructor(key) {
     this._key = key;
-    this._rest = rest;
   }
 
   /**
@@ -25,13 +24,7 @@ export class Endpoint {
    * @return {Rest}
    */
   get(container) {
-    let config = container.get(Config);
-    let endpoint = config.getEndpoint(this._key);
-
-    if (endpoint) return endpoint;
-
-    config.registerEndpoint(this._key, ...this._rest);
-    return config.getEndpoint(this._key);
+    return container.get(Config).getEndpoint(this._key);
   }
 
   /**
@@ -41,7 +34,7 @@ export class Endpoint {
    *
    * @return {Endpoint}  Resolves to the Rest client for this endpoint
    */
-  static of(key, ...rest) {
-    return new Endpoint(key, ...rest);
+  static of(key) {
+    return new Endpoint(key);
   }
 }

--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -1,13 +1,16 @@
 import {resolver} from 'aurelia-dependency-injection';
 import {Config} from './config';
 
+/**
+ * Endpoint class. A resolver for endpoints which allows injection of the corresponding Rest client into a class
+ */
 @resolver()
 export class Endpoint {
 
   /**
    * Construct the resolver with the specified key.
    *
-   * @param {string} key
+   * @type {string} key
    */
   constructor(key) {
     this._key = key;
@@ -16,7 +19,7 @@ export class Endpoint {
   /**
    * Resolve for key.
    *
-   * @param {Container} container
+   * @type {Container} container
    *
    * @return {Rest}
    */
@@ -27,9 +30,9 @@ export class Endpoint {
   /**
    * Get a new resolver for `key`.
    *
-   * @param {string} key
+   * @type {string} key  The endpoint name
    *
-   * @return {Endpoint}
+   * @return {Endpoint}  Resolves to the Rest client for this endpoint
    */
   static of(key) {
     return new Endpoint(key);

--- a/src/endpoint.js
+++ b/src/endpoint.js
@@ -12,8 +12,9 @@ export class Endpoint {
    *
    * @type {string} key
    */
-  constructor(key) {
+  constructor(key, ...rest) {
     this._key = key;
+    this._rest = rest;
   }
 
   /**
@@ -24,7 +25,13 @@ export class Endpoint {
    * @return {Rest}
    */
   get(container) {
-    return container.get(Config).getEndpoint(this._key);
+    let config = container.get(Config);
+    let endpoint = config.getEndpoint(this._key);
+
+    if (endpoint) return endpoint;
+
+    config.registerEndpoint(this._key, ...this._rest);
+    return config.getEndpoint(this._key);
   }
 
   /**
@@ -34,7 +41,7 @@ export class Endpoint {
    *
    * @return {Endpoint}  Resolves to the Rest client for this endpoint
    */
-  static of(key) {
-    return new Endpoint(key);
+  static of(key, ...rest) {
+    return new Endpoint(key, ...rest);
   }
 }

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,18 +1,9 @@
 import {buildQueryString} from 'aurelia-path';
-import extend from 'extend';
 
 /**
  * Rest class. A simple rest client to fetch resources
  */
 export class Rest {
-
-  defaults = {
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'application/json'
-    }
-  }
-
   /**
    * Inject the clientAdapter to use for requests.
    *
@@ -36,23 +27,7 @@ export class Rest {
    * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   request(method, path, body, options = {}) {
-    let requestOptions = extend(true, {headers: {}}, this.defaults, options, {method, body});
-
-    let contentType = requestOptions.headers['Content-Type'] || requestOptions.headers['content-type'];
-
-    if (typeof body === 'object' && contentType) {
-      requestOptions.body = contentType.toLowerCase() === 'application/json'
-                          ? JSON.stringify(body)
-                          : qs.stringify(body);
-    }
-
-    return this.client.fetch(path, requestOptions).then(response => {
-      if (response.status >= 200 && response.status < 400) {
-        return response.json().catch(error => null);
-      }
-
-      throw response;
-    });
+    return this.clientAdapter.request(method, path, body, options);
   }
 
   /**

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,6 +1,9 @@
 import qs from 'qs';
 import extend from 'extend';
 
+/**
+ * Rest class. A simple rest client to fetch resources
+ */
 export class Rest {
 
   defaults = {
@@ -13,8 +16,8 @@ export class Rest {
   /**
    * Inject the httpClient to use for requests.
    *
-   * @param {HttpClient} httpClient
-   * @param {string}     [endpoint]
+   * @type {HttpClient} httpClient The httpClient to use
+   * @type {string}     [endpoint] The endpoint name
    */
   constructor(httpClient, endpoint) {
     this.client   = httpClient;
@@ -24,12 +27,12 @@ export class Rest {
   /**
    * Make a request to the server.
    *
-   * @param {string} method
-   * @param {string} path
-   * @param {{}}     [body]
-   * @param {{}}     [options]
+   * @type {string} method     The fetch method
+   * @type {string} path       Path to the resource
+   * @type {{}}     [body]     The body to send if applicable
+   * @type {{}}     [options]  Fetch options overwrites
    *
-   * @return {Promise}
+   * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   request(method, path, body, options = {}) {
     let requestOptions = extend(true, {headers: {}}, this.defaults, options, {method, body});
@@ -54,11 +57,11 @@ export class Rest {
   /**
    * Find a resource.
    *
-   * @param {string}           resource Resource to find in
-   * @param {{}|string|Number} criteria Object for where clause, string / number for id.
-   * @param {{}}               [options] Extra fetch options.
+   * @type {string}           resource  Resource to find in
+   * @type {{}|string|Number} criteria  Object for where clause, string / number for id.
+   * @type {{}}               [options] Extra fetch options.
    *
-   * @return {Promise}
+   * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   find(resource, criteria, options) {
     let requestPath = resource;
@@ -73,11 +76,11 @@ export class Rest {
   /**
    * Create a new instance for resource.
    *
-   * @param {string} resource
-   * @param {{}}     body
-   * @param {{}}     [options]
+   * @type {string} resource  Resource to create
+   * @type {{}}     body      The data to post (as Object)
+   * @type {{}}     [options] Extra fetch options.
    *
-   * @return {Promise}
+   * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   post(resource, body, options) {
     return this.request('POST', resource, body, options);
@@ -86,12 +89,12 @@ export class Rest {
   /**
    * Update a resource.
    *
-   * @param {string}           resource  Resource to update
-   * @param {{}|string|Number} criteria  Object for where clause, string / number for id.
-   * @param {object}           body      New data for provided criteria.
-   * @param {{}}               [options]
+   * @type {string}           resource  Resource to update
+   * @type {{}|string|Number} criteria  Object for where clause, string / number for id.
+   * @type {object}           body      New data for provided criteria.
+   * @type {{}}               [options] Extra fetch options.
    *
-   * @return {Promise}
+   * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   update(resource, criteria, body, options) {
     let requestPath = resource;
@@ -106,12 +109,12 @@ export class Rest {
   /**
    * Patch a resource.
    *
-   * @param {string}           resource  Resource to patch
-   * @param {{}|string|Number} criteria  Object for where clause, string / number for id.
-   * @param {object}           body      Data to patch for provided criteria.
-   * @param {{}}               [options]
+   * @type {string}           resource  Resource to patch
+   * @type {{}|string|Number} criteria  Object for where clause, string / number for id.
+   * @type {object}           body      Data to patch for provided criteria.
+   * @type {{}}               [options] Extra fetch options.
    *
-   * @return {Promise}
+   * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   patch(resource, criteria, body, options) {
     let requestPath = resource;
@@ -126,11 +129,11 @@ export class Rest {
   /**
    * Delete a resource.
    *
-   * @param {string}           resource  The resource to delete in
-   * @param {{}|string|Number} criteria  Object for where clause, string / number for id.
-   * @param {{}}               [options]
+   * @type {string}           resource  The resource to delete
+   * @type {{}|string|Number} criteria  Object for where clause, string / number for id.
+   * @type {{}}               [options] Extra fetch options.
    *
-   * @return {Promise}
+   * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   destroy(resource, criteria, options) {
     let requestPath = resource;
@@ -145,11 +148,11 @@ export class Rest {
   /**
    * Create a new instance for resource.
    *
-   * @param {string} resource
-   * @param {{}}     body
-   * @param {{}}     [options]
+   * @type {string} resource  The resource to create
+   * @type {{}}     body      The data to post (as Object)
+   * @type {{}}     [options] Extra fetch options.
    *
-   * @return {Promise}
+   * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   create(resource, body, options) {
     return this.post(...arguments);

--- a/src/rest.js
+++ b/src/rest.js
@@ -1,4 +1,4 @@
-import qs from 'qs';
+import {buildQueryString} from 'aurelia-path';
 import extend from 'extend';
 
 /**
@@ -14,14 +14,15 @@ export class Rest {
   }
 
   /**
-   * Inject the httpClient to use for requests.
+   * Inject the clientAdapter to use for requests.
    *
-   * @type {HttpClient} httpClient The httpClient to use
-   * @type {string}     [endpoint] The endpoint name
+   * @type {ClientAdapter} clientAdapter The ClientAdapter to use
+   * @type {string}        endpoint      The endpoint name
    */
-  constructor(httpClient, endpoint) {
-    this.client   = httpClient;
-    this.endpoint = endpoint;
+  constructor(clientAdapter, endpoint) {
+    this.clientAdapter   = clientAdapter;
+    this.client          = clientAdapter.client;
+    this.endpoint        = endpoint;
   }
 
   /**
@@ -64,13 +65,7 @@ export class Rest {
    * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   find(resource, criteria, options) {
-    let requestPath = resource;
-
-    if (criteria) {
-      requestPath += typeof criteria !== 'object' ? `/${criteria}` : '?' + qs.stringify(criteria);
-    }
-
-    return this.request('GET', requestPath, undefined, options);
+    return this.request('GET', getRequestPath(resource, criteria), undefined, options);
   }
 
   /**
@@ -97,13 +92,7 @@ export class Rest {
    * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   update(resource, criteria, body, options) {
-    let requestPath = resource;
-
-    if (criteria) {
-      requestPath += typeof criteria !== 'object' ? `/${criteria}` : '?' + qs.stringify(criteria);
-    }
-
-    return this.request('PUT', requestPath, body, options);
+    return this.request('PUT', getRequestPath(resource, criteria), body, options);
   }
 
   /**
@@ -117,13 +106,7 @@ export class Rest {
    * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   patch(resource, criteria, body, options) {
-    let requestPath = resource;
-
-    if (criteria) {
-      requestPath += typeof criteria !== 'object' ? `/${criteria}` : '?' + qs.stringify(criteria);
-    }
-
-    return this.request('PATCH', requestPath, body, options);
+    return this.request('PATCH', getRequestPath(resource, criteria), body, options);
   }
 
   /**
@@ -136,13 +119,7 @@ export class Rest {
    * @return {Promise<Object>|Promise<Error>} Server response as Object
    */
   destroy(resource, criteria, options) {
-    let requestPath = resource;
-
-    if (criteria) {
-      requestPath += typeof criteria !== 'object' ? `/${criteria}` : '?' + qs.stringify(criteria);
-    }
-
-    return this.request('DELETE', requestPath, undefined, options);
+    return this.request('DELETE', getRequestPath(resource, criteria), undefined, options);
   }
 
   /**
@@ -157,4 +134,10 @@ export class Rest {
   create(resource, body, options) {
     return this.post(...arguments);
   }
+}
+
+function getRequestPath(resource, criteria) {
+  return (criteria !== undefined && criteria !== null
+    ? resource + (typeof criteria !== 'object' ? `/${criteria}` : '?' + buildQueryString(criteria))
+    : resource);
 }

--- a/test/client-adapters/client-adapter.spec.js
+++ b/test/client-adapters/client-adapter.spec.js
@@ -1,0 +1,26 @@
+import {
+  TestClientAdapter,
+  ClientAdapterNoClient,
+  FaultyClientAdapterNoClientConfigure,
+  FaultyClientAdapterNoClientBuilder
+} from '../resources/test-client-adapters';
+
+describe('Client-Adapter', function() {
+  describe('.constructor()', function() {
+    it('Should not fail for a compliant client adapter.', function() {
+      let properAdapter = () => new TestClientAdapter();
+      expect(properAdapter).not.toThrow();
+    });
+
+    it('Should fail for a non-compliant client adapter.', function() {
+      let noClient = () => new ClientAdapterNoClient();
+      expect(noClient).toThrow();
+
+      let clientWithoutConfigure = () => new FaultyClientAdapterNoClientConfigure();
+      expect(clientWithoutConfigure).toThrow();
+
+      let noClientBuilder = () => new FaultyClientAdapterNoClientBuilder();
+      expect(noClientBuilder).toThrow();
+    });
+  });
+});

--- a/test/client-adapters/fetch-client-adapter.spec.js
+++ b/test/client-adapters/fetch-client-adapter.spec.js
@@ -3,7 +3,7 @@ import {HttpClient} from 'aurelia-fetch-client';
 import {buildQueryString} from 'aurelia-path';
 import {settings} from '../resources/settings';
 
-let adapter = new FetchClientAdapter();
+let adapter = new FetchClientAdapter;
 
 describe('FetchClientAdapter', function() {
   describe('.client', function() {

--- a/test/client-adapters/fetch-client-adapter.spec.js
+++ b/test/client-adapters/fetch-client-adapter.spec.js
@@ -103,16 +103,17 @@ describe('FetchClientAdapter', function() {
   });
 
   describe('.post()', function() {
-    it('Should post body (as FormData) and options.', function(done) {
+    it('Should post body (as FormData).', function(done) {
+      adapter.defaults = null;
+
       let data = new FormData();
       data.append('user', 'Jane Doe');
 
-      adapter.request('POST', 'posts', data, settings.optionsForm)
+      adapter.request('POST', 'uploads', data)
         .then(y => {
           expect(y.method).toBe('POST');
-          expect(y.path).toBe('/posts');
-          expect(y.contentType).toMatch(settings.optionsForm.headers['Content-Type']);
-          expect(y.Authorization).toBe(settings.optionsForm.headers['Authorization']);
+          expect(y.path).toBe('/uploads');
+          expect(y.contentType).toMatch('multipart/form-data');
           expect(JSON.stringify(y.body)).toMatch('Jane Doe');
           done();
         });

--- a/test/client-adapters/fetch-client-adapter.spec.js
+++ b/test/client-adapters/fetch-client-adapter.spec.js
@@ -1,0 +1,105 @@
+import {FetchClientAdapter} from '../../src/client-adapters/fetch-client-adapter';
+import {HttpClient} from 'aurelia-fetch-client';
+import {buildQueryString} from 'aurelia-path';
+import {settings} from '../resources/settings';
+
+let adapter = new FetchClientAdapter();
+
+describe('FetchClientAdapter', function() {
+  describe('.client', function() {
+    it('Should be client with configure(config => config.withBaseUrl(base))', function() {
+      expect(adapter.client instanceof HttpClient).toBe(true);
+
+      adapter.client.configure(config => config.withBaseUrl(settings.baseUrls.api));
+      expect(adapter.client.baseUrl).toBe(settings.baseUrls.api);
+    });
+  });
+
+  describe('.find()', function() {
+    it('Should find results for multiple endpoints', function(done) {
+      Promise.all([
+        adapter.request('GET', 'posts')
+          .then(y => {
+            expect(y.method).toBe('GET');
+          }),
+        adapter.request('GET', 'posts')
+          .then(y => {
+            expect(y.path).toBe('/posts');
+          }),
+        adapter.request('GET', 'posts/id')
+          .then(y => {
+            expect(y.path).toBe('/posts/id');
+            expect(JSON.stringify(y.query)).toBe('{}');
+          }),
+        adapter.request('GET', 'posts?' + buildQueryString(settings.criteria))
+          .then(y => {
+            expect(y.path).toBe('/posts');
+            expect(y.query.user).toBe(settings.criteria.user);
+            expect(y.query.comment).toBe(settings.criteria.comment);
+          }),
+        adapter.request('GET', 'posts', undefined, settings.options)
+          .then(y => {
+            expect(y.path).toBe('/posts');
+            expect(y.contentType).toBe(settings.options.headers['Content-Type']);
+            expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          })
+      ]).then(done);
+    });
+  });
+
+  describe('.update()', function() {
+    it('Should update with body (as json), criteria and options.', function(done) {
+      adapter.request('PUT', 'posts?' + buildQueryString(settings.criteria), settings.body, settings.options)
+        .then(y => {
+          expect(y.method).toBe('PUT');
+          expect(y.path).toBe('/posts');
+          expect(y.query.user).toBe(settings.criteria.user);
+          expect(y.query.comment).toBe(settings.criteria.comment);
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.patch()', function() {
+    it('Should patch with body (as json), criteria and options.', function(done) {
+      adapter.request('PATCH', 'post?' + buildQueryString(settings.criteria), settings.body, settings.options)
+        .then(y => {
+          expect(y.method).toBe('PATCH');
+          expect(y.path).toBe('/post');
+          expect(y.query.user).toBe(settings.criteria.user);
+          expect(y.query.comment).toBe(settings.criteria.comment);
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.destroy()', function() {
+    it('Should destroy with id and options .', function(done) {
+      adapter.request('DELETE', 'posts/id', undefined, settings.options)
+        .then(y => {
+          expect(y.method).toBe('DELETE');
+          expect(y.path).toBe('/posts/id');
+          expect(JSON.stringify(y.query)).toBe('{}');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.create()', function() {
+    it('Should create body (as json) and options.', function(done) {
+      adapter.request('POST', 'posts', settings.body, settings.options)
+        .then(y => {
+          expect(y.method).toBe('POST');
+          expect(y.path).toBe('/posts');
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+});

--- a/test/client-adapters/fetch-client-adapter.spec.js
+++ b/test/client-adapters/fetch-client-adapter.spec.js
@@ -40,7 +40,6 @@ describe('FetchClientAdapter', function() {
         adapter.request('GET', 'posts', undefined, settings.options)
           .then(y => {
             expect(y.path).toBe('/posts');
-            expect(y.contentType).toBe(settings.options.headers['Content-Type']);
             expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           })
       ]).then(done);
@@ -98,6 +97,23 @@ describe('FetchClientAdapter', function() {
           expect(y.path).toBe('/posts');
           expect(y.contentType).toMatch('application/json');
           expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.post()', function() {
+    it('Should post body (as FormData) and options.', function(done) {
+      let data = new FormData();
+      data.append('user', 'Jane Doe');
+
+      adapter.request('POST', 'posts', data, settings.optionsForm)
+        .then(y => {
+          expect(y.method).toBe('POST');
+          expect(y.path).toBe('/posts');
+          expect(y.contentType).toMatch(settings.optionsForm.headers['Content-Type']);
+          expect(y.Authorization).toBe(settings.optionsForm.headers['Authorization']);
+          expect(JSON.stringify(y.body)).toMatch('Jane Doe');
           done();
         });
     });

--- a/test/client-adapters/file-client-adapter.spec.js
+++ b/test/client-adapters/file-client-adapter.spec.js
@@ -1,0 +1,35 @@
+import {FileClientAdapter} from '../../src/client-adapters/file-client-adapter';
+import {FileClient} from '../../src/client-adapters/file-client';
+import {buildQueryString} from 'aurelia-path';
+import {settings} from '../resources/settings';
+
+let adapter = new FileClientAdapter();
+
+describe('FileClientAdapter', function() {
+  describe('.client', function() {
+    it('Should be client with configure(config => config.withBaseUrl(base))', function() {
+      expect(adapter.client instanceof FileClient).toBe(true);
+
+      adapter.client.configure(config => config.withBaseUrl(settings.baseUrls.file));
+    });
+  });
+
+  describe('.find()', function() {
+    it('Should find results.', function(done) {
+      Promise.all([
+        adapter.request('', 'posts')
+          .then(y => {
+            expect(JSON.stringify(y)).toBe(JSON.stringify(settings.data));
+          }),
+        adapter.request('', 'posts/0')
+          .then(y => {
+            expect(JSON.stringify(y[0])).toBe(JSON.stringify(settings.data[0]));
+          }),
+        adapter.request('', 'posts?' + buildQueryString(settings.criteria))
+          .then(y => {
+            expect(JSON.stringify(y[0])).toBe(JSON.stringify(settings.data[0]));
+          })
+      ]).then(done);
+    });
+  });
+});

--- a/test/client-adapters/file-client-adapter.spec.js
+++ b/test/client-adapters/file-client-adapter.spec.js
@@ -3,7 +3,7 @@ import {FileClient} from '../../src/client-adapters/file-client';
 import {buildQueryString} from 'aurelia-path';
 import {settings} from '../resources/settings';
 
-let adapter = new FileClientAdapter();
+let adapter = new FileClientAdapter;
 
 describe('FileClientAdapter', function() {
   describe('.client', function() {

--- a/test/client-adapters/http-client-adapter.spec.js
+++ b/test/client-adapters/http-client-adapter.spec.js
@@ -3,7 +3,7 @@ import {HttpClient} from 'aurelia-http-client';
 import {buildQueryString} from 'aurelia-path';
 import {settings} from '../resources/settings';
 
-let adapter = new HttpClientAdapter();
+let adapter = new HttpClientAdapter;
 
 describe('HttpClientAdapter', function() {
   describe('.client', function() {

--- a/test/client-adapters/http-client-adapter.spec.js
+++ b/test/client-adapters/http-client-adapter.spec.js
@@ -39,7 +39,6 @@ describe('HttpClientAdapter', function() {
         adapter.request('GET', 'posts', undefined, settings.options)
           .then(y => {
             expect(y.path).toBe('/posts');
-            expect(y.contentType).toBe(settings.options.headers['Content-Type']);
             expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           })
       ]).then(done);
@@ -97,6 +96,23 @@ describe('HttpClientAdapter', function() {
           expect(y.path).toBe('/posts');
           expect(y.contentType).toMatch('application/json');
           expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.post()', function() {
+    it('Should post body (as FormData) and options.', function(done) {
+      let data = new FormData();
+      data.append('user', 'Jane Doe');
+
+      adapter.request('POST', 'posts', data, settings.optionsForm)
+        .then(y => {
+          expect(y.method).toBe('POST');
+          expect(y.path).toBe('/posts');
+          expect(y.contentType).toMatch(settings.optionsForm.headers['Content-Type']);
+          expect(y.Authorization).toBe(settings.optionsForm.headers['Authorization']);
+          expect(JSON.stringify(y.body)).toMatch('Jane Doe');
           done();
         });
     });

--- a/test/client-adapters/http-client-adapter.spec.js
+++ b/test/client-adapters/http-client-adapter.spec.js
@@ -1,0 +1,104 @@
+import {HttpClientAdapter} from '../../src/client-adapters/http-client-adapter';
+import {HttpClient} from 'aurelia-http-client';
+import {buildQueryString} from 'aurelia-path';
+import {settings} from '../resources/settings';
+
+let adapter = new HttpClientAdapter();
+
+describe('HttpClientAdapter', function() {
+  describe('.client', function() {
+    it('Should be client with configure(config => config.withBaseUrl(base))', function() {
+      expect(adapter.client instanceof HttpClient).toBe(true);
+
+      adapter.client.configure(config => config.withBaseUrl(settings.baseUrls.api));
+    });
+  });
+
+  describe('.find()', function() {
+    it('Should find results for multiple endpoints', function(done) {
+      Promise.all([
+        adapter.request('GET', 'posts')
+          .then(y => {
+            expect(y.method).toBe('GET');
+          }),
+        adapter.request('GET', 'posts')
+          .then(y => {
+            expect(y.path).toBe('/posts');
+          }),
+        adapter.request('GET', 'posts/id')
+          .then(y => {
+            expect(y.path).toBe('/posts/id');
+            expect(JSON.stringify(y.query)).toBe('{}');
+          }),
+        adapter.request('GET', 'posts?' + buildQueryString(settings.criteria))
+          .then(y => {
+            expect(y.path).toBe('/posts');
+            expect(y.query.user).toBe(settings.criteria.user);
+            expect(y.query.comment).toBe(settings.criteria.comment);
+          }),
+        adapter.request('GET', 'posts', undefined, settings.options)
+          .then(y => {
+            expect(y.path).toBe('/posts');
+            expect(y.contentType).toBe(settings.options.headers['Content-Type']);
+            expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          })
+      ]).then(done);
+    });
+  });
+
+  describe('.update()', function() {
+    it('Should update with body (as json), criteria and options.', function(done) {
+      adapter.request('PUT', 'posts?' + buildQueryString(settings.criteria), settings.body, settings.options)
+        .then(y => {
+          expect(y.method).toBe('PUT');
+          expect(y.path).toBe('/posts');
+          expect(y.query.user).toBe(settings.criteria.user);
+          expect(y.query.comment).toBe(settings.criteria.comment);
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.patch()', function() {
+    it('Should patch with body (as json), criteria and options.', function(done) {
+      adapter.request('PATCH', 'post?' + buildQueryString(settings.criteria), settings.body, settings.options)
+        .then(y => {
+          expect(y.method).toBe('PATCH');
+          expect(y.path).toBe('/post');
+          expect(y.query.user).toBe(settings.criteria.user);
+          expect(y.query.comment).toBe(settings.criteria.comment);
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.destroy()', function() {
+    it('Should destroy with id and options.', function(done) {
+      adapter.request('DELETE', 'posts/id', undefined, settings.options)
+        .then(y => {
+          expect(y.method).toBe('DELETE');
+          expect(y.path).toBe('/posts/id');
+          expect(JSON.stringify(y.query)).toBe('{}');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+
+  describe('.create()', function() {
+    it('Should create body (as json) and options.', function(done) {
+      adapter.request('POST', 'posts', settings.body, settings.options)
+        .then(y => {
+          expect(y.method).toBe('POST');
+          expect(y.path).toBe('/posts');
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
+          done();
+        });
+    });
+  });
+});

--- a/test/client-adapters/jsonp-client-adapter.spec.js
+++ b/test/client-adapters/jsonp-client-adapter.spec.js
@@ -1,0 +1,37 @@
+import {JSONPClientAdapter} from '../../src/client-adapters/jsonp-client-adapter';
+import {HttpClient} from 'aurelia-http-client';
+import {buildQueryString} from 'aurelia-path';
+import {settings} from '../resources/settings';
+
+let adapter = new JSONPClientAdapter();
+
+describe('JSONPClientAdapter', function() {
+  describe('.client', function() {
+    it('Should be client with configure(config => config.withBaseUrl(base))', function() {
+      expect(adapter.client instanceof HttpClient).toBe(true);
+
+      adapter.client.configure(config => config.withBaseUrl(settings.baseUrls.jsonp));
+    });
+  });
+
+  describe('.find()', function() {
+    it('Should find results.', function(done) {
+      Promise.all([
+        adapter.request('', 'posts')
+          .then(y => {
+            expect(y.path).toBe('/jsonp/posts');
+          }),
+        adapter.request('', 'posts/id')
+          .then(y => {
+            expect(y.path).toBe('/jsonp/posts/id');
+          }),
+        adapter.request('', 'posts?' + buildQueryString(settings.criteria))
+          .then(y => {
+            expect(y.path).toBe('/jsonp/posts');
+            expect(y.query.user).toBe(settings.criteria.user);
+            expect(y.query.comment).toBe(settings.criteria.comment);
+          })
+      ]).then(done);
+    });
+  });
+});

--- a/test/client-adapters/jsonp-client-adapter.spec.js
+++ b/test/client-adapters/jsonp-client-adapter.spec.js
@@ -3,7 +3,7 @@ import {HttpClient} from 'aurelia-http-client';
 import {buildQueryString} from 'aurelia-path';
 import {settings} from '../resources/settings';
 
-let adapter = new JSONPClientAdapter();
+let adapter = new JSONPClientAdapter;
 
 describe('JSONPClientAdapter', function() {
   describe('.client', function() {

--- a/test/client-adapters/storage-client-adapter.spec.js
+++ b/test/client-adapters/storage-client-adapter.spec.js
@@ -1,0 +1,126 @@
+import {StorageClientAdapter} from '../../src/client-adapters/storage-client-adapter';
+import {StorageClient} from '../../src/client-adapters/storage-client';
+import {buildQueryString} from 'aurelia-path';
+import {settings} from '../resources/settings';
+
+
+let adapter = new StorageClientAdapter();
+let key = 'AureliaStorageClient-' + settings.baseUrls.api + 'posts';
+
+describe('StorageClientAdapter', function() {
+  beforeEach(function() {
+    StorageClient.clear(window.localStorage);
+    adapter.client.storage.setItem(key, JSON.stringify(settings.data));
+  });
+
+  describe('.client', function() {
+    it('Should be client with configure(config => config.withBaseUrl(base))', function() {
+      expect(adapter.client instanceof StorageClient).toBe(true);
+
+      adapter.client.configure(config => config.withBaseUrl(settings.baseUrls.api));
+    });
+  });
+
+  describe('.find()', function() {
+    it('Should find results with StorageClientAdapter.', function(done) {
+      Promise.all([
+        adapter.request('GET', 'posts')
+          .then(y => {
+            expect(JSON.stringify(y)).toBe(JSON.stringify(settings.data));
+          }),
+        adapter.request('GET', 'posts/0')
+          .then(y => {
+            expect(y.id).toBe(0);
+          }),
+        adapter.request('GET', 'posts?' + buildQueryString(settings.criteria))
+          .then(y => {
+            expect(y.user).toBe(settings.criteria.user);
+            expect(y.comment).toBe(settings.criteria.comment);
+          }),
+        adapter.request('GET', 'posts?' + buildQueryString({user: 'john'}))
+          .then(y => {
+            expect(y[0].user).toBe('john');
+            expect(y.length).toBe(2);
+          })
+      ]).then(done);
+    });
+  });
+
+  describe('.update()', function() {
+    it('Should update with body (as json), criteria.', function(done) {
+      adapter.request('PUT', 'posts?' + buildQueryString(settings.criteria), settings.body)
+        .then(y => {
+          expect(y.length).toBe(1);
+          expect(y[0].user).toBe(undefined);
+          expect(y[0].comment).toBe(undefined);
+          expect(y[0].message).toBe('some');
+
+          let res = JSON.parse(adapter.client.storage.getItem(key));
+          expect(res.length).toBe(3);
+          expect(res[0].id).toBe(0);
+          expect(res[0].message).toBe('some');
+          expect(res[0].user).toBe(undefined);
+          expect(res[0].comment).toBe(undefined);
+          expect(res[1].message).toBeUndefined();
+          expect(res[2].message).toBeUndefined();
+          done();
+        });
+    });
+  });
+
+  describe('.patch()', function() {
+    it('Should patch with body (as json), criteria.', function(done) {
+      adapter.request('PATCH', 'posts?' + buildQueryString(settings.criteria), settings.body)
+        .then(y => {
+          expect(y.length).toBe(1);
+          expect(y[0].user).toBe('john');
+          expect(y[0].comment).toBe('last');
+          expect(y[0].message).toBe('some');
+
+          let res = JSON.parse(adapter.client.storage.getItem(key));
+          expect(res.length).toBe(3);
+          expect(res[0].id).toBe(0);
+          expect(res[0].message).toBe('some');
+          expect(res[0].user).toBe('john');
+          expect(res[0].comment).toBe('last');
+          expect(res[1].message).toBeUndefined();
+          expect(res[2].message).toBeUndefined();
+          done();
+        });
+    });
+  });
+
+  describe('.destroy()', function() {
+    it('Should destroy with id.', function(done) {
+      adapter.request('DELETE', 'posts/0')
+        .then(y => {
+          expect(y[0].id).toBe(0);
+          expect(y[0].user).toBe('john');
+          expect(y[0].comment).toBe('last');
+
+          let res = JSON.parse(adapter.client.storage.getItem(key));
+          expect(res.length).toBe(2);
+          expect(res[0].id).toBe(1);
+          expect(res[0].comment).toBe('first');
+          expect(res[1].user).toBe('jane');
+          done();
+        });
+    });
+  });
+
+  describe('.create()', function() {
+    it('Should create body (as json).', function(done) {
+      adapter.request('POST', 'posts', {user: 'jim'})
+        .then(y => {
+          expect(y.id).toBe(3);
+          expect(y.user).toBe('jim');
+
+          let res = JSON.parse(adapter.client.storage.getItem(key));
+          expect(res.length).toBe(4);
+          expect(res[3].id).toBe(3);
+          expect(res[3].user).toBe('jim');
+          done();
+        });
+    });
+  });
+});

--- a/test/client-adapters/storage-client-adapter.spec.js
+++ b/test/client-adapters/storage-client-adapter.spec.js
@@ -3,8 +3,7 @@ import {StorageClient} from '../../src/client-adapters/storage-client';
 import {buildQueryString} from 'aurelia-path';
 import {settings} from '../resources/settings';
 
-
-let adapter = new StorageClientAdapter();
+let adapter = new StorageClientAdapter;
 let key = 'AureliaStorageClient-' + settings.baseUrls.api + 'posts';
 
 describe('StorageClientAdapter', function() {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -5,6 +5,7 @@ import {HttpClientAdapter} from '../src/client-adapters/http-client-adapter';
 import {StorageClientAdapter} from '../src/client-adapters/storage-client-adapter';
 import {StorageClient} from '../src/client-adapters/storage-client';
 import {settings} from './resources/settings';
+import extend from 'extend';
 
 describe('Config', function() {
   it('Should use the DefaultClientAdapter.', function() {

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -1,7 +1,9 @@
-import {HttpClient} from 'aurelia-fetch-client';
+import {HttpClient as FetchClient} from 'aurelia-fetch-client';
 import {Config, Rest} from '../src/aurelia-api';
 import {FetchClientAdapter} from '../src/client-adapters/fetch-client-adapter';
 import {HttpClientAdapter} from '../src/client-adapters/http-client-adapter';
+import {StorageClientAdapter} from '../src/client-adapters/storage-client-adapter';
+import {StorageClient} from '../src/client-adapters/storage-client';
 import {settings} from './resources/settings';
 
 describe('Config', function() {
@@ -53,12 +55,24 @@ describe('Config', function() {
 
     it('Should properly register an endpoint when providing the http client adapter.', function() {
       let config   = new Config;
-      let returned = config.registerEndpoint('api', settings.baseUrls.api, {}, HttpClientAdapter);
+      let returned = config.registerEndpoint('api', settings.baseUrls.api, {}, new HttpClientAdapter);
 
       let message = {};
       config.endpoints.api.client.requestTransformers[0](null, null, message);
 
       expect(message.baseUrl).toEqual(settings.baseUrls.api);
+      expect(returned).toBe(config);
+    });
+
+    it('Should properly register an endpoint when providing the storage client adapter useing sessionStorage.', function() {
+      let config   = new Config;
+      let storageClient = new StorageClient(sessionStorage);
+      let returned = config.registerEndpoint('api', settings.baseUrls.api, {}, new StorageClientAdapter(storageClient));
+      let endpoint = config.getEndpoint('api');
+
+      expect(endpoint.client.baseUrl).toEqual(settings.baseUrls.api);
+      expect(endpoint.client).toEqual(storageClient);
+      expect(endpoint.client.storage).toEqual(sessionStorage);
       expect(returned).toBe(config);
     });
 
@@ -81,7 +95,7 @@ describe('Config', function() {
       let defaultNullEndpoint = config.getEndpoint();
 
       expect(endpoint instanceof Rest).toBe(true);
-      expect(endpoint.client instanceof HttpClient).toBe(true);
+      expect(endpoint.client instanceof FetchClient).toBe(true);
       expect(nullEndpoint instanceof Rest).toBe(false);
       expect(nullEndpoint).toBe(null);
       expect(defaultNullEndpoint instanceof Rest).toBe(false);
@@ -92,7 +106,7 @@ describe('Config', function() {
       let defaultEndpoint = config.getEndpoint();
 
       expect(defaultEndpoint instanceof Rest).toBe(true);
-      expect(defaultEndpoint.client instanceof HttpClient).toBe(true);
+      expect(defaultEndpoint.client instanceof FetchClient).toBe(true);
     });
   });
 

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -2,6 +2,7 @@ import {HttpClient} from 'aurelia-fetch-client';
 import {Config, Rest} from '../src/aurelia-api';
 import {FetchClientAdapter} from '../src/client-adapters/fetch-client-adapter';
 import {HttpClientAdapter} from '../src/client-adapters/http-client-adapter';
+import {settings} from './resources/settings';
 
 describe('Config', function() {
   it('Should use the DefaultClientAdapter.', function() {
@@ -14,23 +15,21 @@ describe('Config', function() {
     it('Should properly register an endpoint when providing a config callback.', function() {
       let config   = new Config;
       let returned = config.registerEndpoint('github', function(configure) {
-        configure.withBaseUrl(baseUrls.github);
-        configure.withDefaults(userOptions);
+        configure.withBaseUrl(settings.baseUrls.github);
       });
 
       expect(config.endpoints.github instanceof Rest).toBe(true);
-      expect(config.endpoints.github.defaults).toEqual(defaultOptions);
-      expect(config.endpoints.github.client.defaults).toEqual(userOptions);
-      expect(config.endpoints.github.client.baseUrl).toEqual(baseUrls.github);
+      expect(config.endpoints.github.clientAdapter.defaults).toEqual(extend(true, {}, settings.defaults));
+      expect(config.endpoints.github.client.baseUrl).toEqual(settings.baseUrls.github);
       expect(returned).toBe(config);
     });
 
     it('Should properly register an endpoint when providing an endpoint string.', function() {
       let config   = new Config;
-      let returned = config.registerEndpoint('api', baseUrls.api);
+      let returned = config.registerEndpoint('api', settings.baseUrls.api);
 
-      expect(config.endpoints.api.defaults).toEqual(defaultOptions);
-      expect(config.endpoints.api.client.baseUrl).toEqual(baseUrls.api);
+      expect(config.endpoints.api.clientAdapter.defaults).toEqual(settings.defaults);
+      expect(config.endpoints.api.client.baseUrl).toEqual(settings.baseUrls.api);
       expect(returned).toBe(config);
     });
 
@@ -38,35 +37,35 @@ describe('Config', function() {
       let config   = new Config;
       let returned = config.registerEndpoint('boring');
 
-      expect(config.endpoints.boring.defaults).toEqual(defaultOptions);
+      expect(config.endpoints.boring.clientAdapter.defaults).toEqual(settings.defaults);
       expect(config.endpoints.boring.client.baseUrl).toEqual('');
       expect(returned).toBe(config);
     });
 
     it('Should properly register an endpoint when providing an endpoint string and defaults.', function() {
       let config   = new Config;
-      let returned = config.registerEndpoint('api', baseUrls.api, userOptions);
+      let returned = config.registerEndpoint('api', settings.baseUrls.api, settings.userOptions);
 
-      expect(config.endpoints.api.defaults).toEqual(userOptions);
-      expect(config.endpoints.api.client.baseUrl).toEqual(baseUrls.api);
+      expect(config.endpoints.api.clientAdapter.defaults).toEqual(extend(true, {}, settings.defaults, settings.userOptions));
+      expect(config.endpoints.api.client.baseUrl).toEqual(settings.baseUrls.api);
       expect(returned).toBe(config);
     });
 
     it('Should properly register an endpoint when providing the http client adapter.', function() {
       let config   = new Config;
-      let returned = config.registerEndpoint('api', baseUrls.api, {}, HttpClientAdapter);
+      let returned = config.registerEndpoint('api', settings.baseUrls.api, {}, HttpClientAdapter);
 
       let message = {};
       config.endpoints.api.client.requestTransformers[0](null, null, message);
 
-      expect(message.baseUrl).toEqual(baseUrls.api);
+      expect(message.baseUrl).toEqual(settings.baseUrls.api);
       expect(returned).toBe(config);
     });
 
     it('Should fail to register an endpoint when providing a non-compliant client adapter.', function() {
       let config   = new Config;
 
-      let wrongClass = () => config.registerEndpoint('api', baseUrls.api, {}, Object);
+      let wrongClass = () => config.registerEndpoint('api', settings.baseUrls.api, {}, Object);
       expect(wrongClass).toThrow();
     });
   });
@@ -75,7 +74,7 @@ describe('Config', function() {
     it('Should return the registered endpoint, or null.', function() {
       let config = new Config;
 
-      config.registerEndpoint('api', baseUrls.api);
+      config.registerEndpoint('api', settings.baseUrls.api);
 
       let endpoint            = config.getEndpoint('api');
       let nullEndpoint        = config.getEndpoint('no');
@@ -101,7 +100,7 @@ describe('Config', function() {
     it('Should return if given name is a registered endpoint.', function() {
       let config = new Config;
 
-      config.registerEndpoint('api', baseUrls.api);
+      config.registerEndpoint('api', settings.baseUrls.api);
 
       expect(config.endpointExists('api')).toBe(true);
       expect(config.endpointExists('cake')).toBe(false);
@@ -113,7 +112,7 @@ describe('Config', function() {
     it('Should set the default endpoint.', function() {
       let config = new Config;
 
-      config.registerEndpoint('api', baseUrls.api);
+      config.registerEndpoint('api', settings.baseUrls.api);
       expect(config.getEndpoint()).toBe(null);
       config.setDefaultEndpoint('api');
       expect(config.getEndpoint() instanceof Rest).toBe(true);
@@ -129,19 +128,3 @@ describe('Config', function() {
     });
   });
 });
-
-let baseUrls = {
-  github: 'https://api.github.com',
-  api   : 'http://jsonplaceholder.typicode.com'
-};
-
-let defaultOptions = {
-  'headers': {
-    'Accept': 'application/json',
-    'Content-Type': 'application/json'
-  }};
-
-let userOptions = {
-  'headers': {
-    'x-scope': 'Tests'
-  }};

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -8,7 +8,7 @@ describe('Config', function() {
   it('Should use the DefaultClientAdapter.', function() {
     let config = new Config;
 
-    expect(config.defaultClientAdapter).toBe(FetchClientAdapter);
+    expect(config.DefaultClientAdapter).toBe(FetchClientAdapter);
   });
 
   describe('.registerEndpoint()', function() {
@@ -124,7 +124,7 @@ describe('Config', function() {
       let config = new Config;
 
       config.setDefaultClientAdapter(HttpClientAdapter);
-      expect(config.defaultClientAdapter).toBe(HttpClientAdapter);
+      expect(config.DefaultClientAdapter).toBe(HttpClientAdapter);
     });
   });
 });

--- a/test/resources/inject-test.js
+++ b/test/resources/inject-test.js
@@ -1,11 +1,12 @@
 import {inject} from 'aurelia-dependency-injection';
 import {Endpoint} from '../../src/aurelia-api';
 
-@inject(Endpoint.of('api'), Endpoint.of('github'), Endpoint.of('form'))
+@inject(Endpoint.of('api'), Endpoint.of('github'), Endpoint.of('form'), Endpoint.of('test'))
 export class InjectTest {
-  constructor(apiEndpoint, githubEndpoint, formEndpoint) {
+  constructor(apiEndpoint, githubEndpoint, formEndpoint, testEndpoint) {
     this.apiEndpoint    = apiEndpoint;
     this.githubEndpoint = githubEndpoint;
-    this.formEndpoint = formEndpoint;
+    this.formEndpoint   = formEndpoint;
+    this.testEndpoint   = testEndpoint;
   }
 }

--- a/test/resources/posts.json
+++ b/test/resources/posts.json
@@ -1,0 +1,5 @@
+[
+    {"id": 0, "user": "john", "comment": "last"},
+    {"id": 1, "user": "john", "comment": "first"},
+    {"id": 2, "user": "jane"}
+]

--- a/test/resources/settings.js
+++ b/test/resources/settings.js
@@ -1,13 +1,29 @@
 export let settings = {
   baseUrls: {
-    github: 'https://api.github.com/',
-    api   : 'http://127.0.0.1:1927/',
-    jsonp : 'http://127.0.0.1:1927/jsonp/',
-    file  : './test/resources/'
+    github   : 'https://api.github.com/',
+    api      : 'http://127.0.0.1:1927/',
+    jsonp    : 'http://127.0.0.1:1927/jsonp/',
+    file     : './test/resources/'
   },
   criteria: {user: 'john', comment: 'last'},
   body: {message: 'some'},
+  defaults: {
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json'
+    }
+  },
+  userOptions: {
+    headers: {
+      'x-scope': 'Tests'
+    }
+  },
   options: {
+    headers: {
+      'Authorization': 'Bearer aToken'
+    }
+  },
+  optionsForm: {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
       'Authorization': 'Bearer aToken'

--- a/test/resources/settings.js
+++ b/test/resources/settings.js
@@ -1,0 +1,19 @@
+export let settings = {
+  baseUrls: {
+    github: 'https://api.github.com/',
+    api   : 'http://127.0.0.1:1927/',
+    jsonp : 'http://127.0.0.1:1927/jsonp/',
+    file  : './test/resources/'
+  },
+  criteria: {user: 'john', comment: 'last'},
+  body: {message: 'some'},
+  options: {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Authorization': 'Bearer aToken'
+    }
+  },
+  data: [{id: 0, user: 'john', comment: 'last'},
+         {id: 1, user: 'john', comment: 'first'},
+        {id: 2, user: 'jane'}]
+};

--- a/test/resources/test-client-adapters.js
+++ b/test/resources/test-client-adapters.js
@@ -6,8 +6,8 @@ export class TestClientAdapter extends ClientAdapter {
     super(client);
   }
 
-  request(method, path, body, optionsCopy = {}) {
-    return this.client.send(method, path, body, optionsCopy);
+  request(method, path, body, options = {}) {
+    return this.client.send(method, path, body, options);
   }
 
   static Client = TestClient;

--- a/test/resources/test-client-adapters.js
+++ b/test/resources/test-client-adapters.js
@@ -1,0 +1,30 @@
+import {ClientAdapter} from '../../src/client-adapters/client-adapter';
+import {TestClient, ClientNoBuilder} from './test-client';
+
+export class TestClientAdapter extends ClientAdapter {
+  constructor(client = new TestClient()) {
+    super(client);
+  }
+
+  request(method, path, body, optionsCopy = {}) {
+    return this.client.send(method, path, body, optionsCopy);
+  }
+}
+
+export class ClientAdapterNoClient extends ClientAdapter {
+  constructor() {
+    super();
+  }
+}
+
+export class FaultyClientAdapterNoClientConfigure extends ClientAdapter {
+  constructor(client = {}) {
+    super(client);
+  }
+}
+
+export class FaultyClientAdapterNoClientBuilder extends ClientAdapter {
+  constructor(client = new ClientNoBuilder()) {
+    super(client);
+  }
+}

--- a/test/resources/test-client-adapters.js
+++ b/test/resources/test-client-adapters.js
@@ -9,6 +9,8 @@ export class TestClientAdapter extends ClientAdapter {
   request(method, path, body, optionsCopy = {}) {
     return this.client.send(method, path, body, optionsCopy);
   }
+
+  static Client = TestClient;
 }
 
 export class ClientAdapterNoClient extends ClientAdapter {

--- a/test/resources/test-client.js
+++ b/test/resources/test-client.js
@@ -4,7 +4,7 @@ export class TestClient {
   builder = {
     withBaseUrl: baseUrl => {
       this.baseUrl = baseUrl;
-      return baseUrl;
+      return this.builder;
     }
   };
 

--- a/test/resources/test-client.js
+++ b/test/resources/test-client.js
@@ -1,0 +1,33 @@
+export class TestClient {
+  baseUrl = '';
+
+  builder = {
+    withBaseUrl: baseUrl => {
+      this.baseUrl = baseUrl;
+      return baseUrl;
+    }
+  };
+
+  configure(_configure) {
+    if (typeof _configure === 'function') {
+      _configure(this.builder);
+    } else if (typeof _configure === 'string') {
+      this.baseUrl = _configure;
+    }
+  }
+
+  send(method, path, body, options) {
+    return Promise.resolve({method, path, body, options});
+  }
+}
+
+
+export class ClientNoBuilder {
+  baseUrl = '';
+
+  configure(_configure) {
+    if (typeof _configure === 'function') {
+      _configure();
+    }
+  }
+}

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -57,7 +57,6 @@ describe('Rest', function() {
         injectTest.apiEndpoint.find('posts', undefined, settings.options)
           .then(y => {
             expect(y.path).toBe('/posts');
-            expect(y.contentType).toBe(settings.options.headers['Content-Type']);
             expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           })
       ]).then(done);

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -25,10 +25,13 @@ describe('Rest', function() {
       expect(injectTest.apiEndpoint instanceof Rest).toBe(true);
       expect(injectTest.githubEndpoint instanceof Rest).toBe(true);
       expect(injectTest.testEndpoint instanceof Rest).toBe(true);
+      expect(injectTest.newEndpoint instanceof Rest).toBe(true);
 
       expect(injectTest.apiEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
       expect(injectTest.githubEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
       expect(injectTest.testEndpoint.clientAdapter instanceof TestClientAdapter).toBe(true);
+      expect(injectTest.newEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
+      expect(injectTest.newEndpoint.clientAdapter.defaults.options).toBe('any');
 
       Promise.all([
         injectTest.githubEndpoint.find('repos/spoonx/aurelia-orm/contributors')

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -1,34 +1,34 @@
 import {Config, Rest} from '../src/aurelia-api';
 import {Container} from 'aurelia-dependency-injection';
 import {InjectTest} from './resources/inject-test';
+import {FetchClientAdapter} from '../src/client-adapters/fetch-client-adapter';
+import {TestClientAdapter} from './resources/test-client-adapters';
+import {settings} from './resources/settings';
 
 let container = new Container();
 let config    = container.get(Config);
-let baseUrls  = {
-  github: 'https://api.github.com/',
-  api   : 'http://127.0.0.1:1927/'
-};
 
-config.registerEndpoint('api', baseUrls.api);
-config.registerEndpoint('github', baseUrls.github);
-config.registerEndpoint('form', baseUrls.api, null);
-
-let criteria = {user: 'john', comment: 'last'};
-let body = {message: 'some'};
-let options = {
-  headers: {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    'Authorization': 'Bearer aToken'
-  }
-};
+config.registerEndpoint('api', settings.baseUrls.api);
+config.registerEndpoint('github', settings.baseUrls.github);
+config.registerEndpoint('form', settings.baseUrls.form, null);
+config.registerEndpoint('test', settings.baseUrls.github, null, TestClientAdapter);
 
 describe('Rest', function() {
+  FetchClientAdapter.request = function(method, path, body, requestOptions) {
+    return {method, path, body, requestOptions};
+  };
+
   describe('.find()', function() {
-    it('Should find results for multiple endpoints.', function(done) {
+    it('Should find results for multiple endpoints (with default ClientAdapter).', function(done) {
       let injectTest = container.get(InjectTest);
 
       expect(injectTest.apiEndpoint instanceof Rest).toBe(true);
       expect(injectTest.githubEndpoint instanceof Rest).toBe(true);
+      expect(injectTest.testEndpoint instanceof Rest).toBe(true);
+
+      expect(injectTest.apiEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
+      expect(injectTest.githubEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
+      expect(injectTest.testEndpoint.clientAdapter instanceof TestClientAdapter).toBe(true);
 
       Promise.all([
         injectTest.githubEndpoint.find('repos/spoonx/aurelia-orm/contributors')
@@ -48,20 +48,19 @@ describe('Rest', function() {
             expect(y.path).toBe('/posts/id');
             expect(JSON.stringify(y.query)).toBe('{}');
           }),
-        injectTest.apiEndpoint.find('posts', criteria)
+        injectTest.apiEndpoint.find('posts', settings.criteria)
           .then(y => {
             expect(y.path).toBe('/posts');
-            expect(JSON.stringify(y.query)).toBe(JSON.stringify(criteria));
+            expect(y.query.user).toBe(settings.criteria.user);
+            expect(y.query.comment).toBe(settings.criteria.comment);
           }),
-        injectTest.apiEndpoint.find('posts', undefined, options)
+        injectTest.apiEndpoint.find('posts', undefined, settings.options)
           .then(y => {
             expect(y.path).toBe('/posts');
-            expect(y.contentType).toBe(options.headers['Content-Type']);
-            expect(y.Authorization).toBe(options.headers['Authorization']);
+            expect(y.contentType).toBe(settings.options.headers['Content-Type']);
+            expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           })
-      ]).then(x => {
-        done();
-      });
+      ]).then(done);
     });
   });
 
@@ -81,13 +80,14 @@ describe('Rest', function() {
     it('Should update with body (as json), criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.update('posts', criteria, body, options)
+      injectTest.apiEndpoint.update('posts', settings.criteria, settings.body, settings.options)
         .then(y => {
           expect(y.method).toBe('PUT');
           expect(y.path).toBe('/posts');
-          expect(JSON.stringify(y.query)).toBe(JSON.stringify(criteria));
-          expect(y.contentType).toMatch(options.headers['Content-Type']);
-          expect(y.Authorization).toBe(options.headers['Authorization']);
+          expect(y.query.user).toBe(settings.criteria.user);
+          expect(y.query.comment).toBe(settings.criteria.comment);
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           done();
         });
     });
@@ -109,28 +109,29 @@ describe('Rest', function() {
     it('Should patch with body (as json), criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.patch('post', criteria, body, options)
+      injectTest.apiEndpoint.patch('post', settings.criteria, settings.body, settings.options)
         .then(y => {
           expect(y.method).toBe('PATCH');
           expect(y.path).toBe('/post');
-          expect(JSON.stringify(y.query)).toBe(JSON.stringify(criteria));
-          expect(y.contentType).toMatch(options.headers['Content-Type']);
-          expect(y.Authorization).toBe(options.headers['Authorization']);
+          expect(y.query.user).toBe(settings.criteria.user);
+          expect(y.query.comment).toBe(settings.criteria.comment);
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           done();
         });
     });
   });
 
   describe('.destroy()', function() {
-    it('Should destroy with id and options.', function(done) {
+    it('Should destroy with id and settings.options .', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.destroy('posts', 'id', options)
+      injectTest.apiEndpoint.destroy('posts', 'id', settings.options)
         .then(y => {
           expect(y.method).toBe('DELETE');
           expect(y.path).toBe('/posts/id');
           expect(JSON.stringify(y.query)).toBe('{}');
-          expect(y.Authorization).toBe(options.headers['Authorization']);
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           done();
         });
     });
@@ -152,12 +153,12 @@ describe('Rest', function() {
     it('Should create body (as json) and options.', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.create('posts', body, options)
+      injectTest.apiEndpoint.create('posts', settings.body, settings.options)
         .then(y => {
           expect(y.method).toBe('POST');
           expect(y.path).toBe('/posts');
-          expect(y.contentType).toMatch(options.headers['Content-Type']);
-          expect(y.Authorization).toBe(options.headers['Authorization']);
+          expect(y.contentType).toMatch('application/json');
+          expect(y.Authorization).toBe(settings.options.headers['Authorization']);
           done();
         });
     });
@@ -173,7 +174,6 @@ describe('Rest', function() {
           expect(y.method).toBe('POST');
           expect(y.path).toBe('/posts');
           expect(y.contentType).toMatch(options.headers['Content-Type']);
-          expect(y.Authorization).toBe(options.headers['Authorization']);
           done();
         });
     });

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -10,8 +10,8 @@ let config    = container.get(Config);
 
 config.registerEndpoint('api', settings.baseUrls.api);
 config.registerEndpoint('github', settings.baseUrls.github);
-config.registerEndpoint('form', settings.baseUrls.form, null);
-config.registerEndpoint('test', settings.baseUrls.github, null, TestClientAdapter);
+config.registerEndpoint('form', settings.baseUrls.api, null);
+config.registerEndpoint('test', settings.baseUrls.github, null, new TestClientAdapter);
 
 describe('Rest', function() {
   FetchClientAdapter.request = function(method, path, body, requestOptions) {
@@ -24,10 +24,12 @@ describe('Rest', function() {
 
       expect(injectTest.apiEndpoint instanceof Rest).toBe(true);
       expect(injectTest.githubEndpoint instanceof Rest).toBe(true);
+      expect(injectTest.formEndpoint instanceof Rest).toBe(true);
       expect(injectTest.testEndpoint instanceof Rest).toBe(true);
 
       expect(injectTest.apiEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
       expect(injectTest.githubEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
+      expect(injectTest.formEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
       expect(injectTest.testEndpoint.clientAdapter instanceof TestClientAdapter).toBe(true);
 
       Promise.all([
@@ -67,7 +69,7 @@ describe('Rest', function() {
     it('Should update with body (as json).', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.update('posts', null, body)
+      injectTest.apiEndpoint.update('posts', null, settings.body)
         .then(y => {
           expect(y.method).toBe('PUT');
           expect(y.path).toBe('/posts');
@@ -96,7 +98,7 @@ describe('Rest', function() {
     it('Should patch with body (as json).', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.patch('post', null, body)
+      injectTest.apiEndpoint.patch('post', null, settings.body)
         .then(y => {
           expect(y.method).toBe('PATCH');
           expect(y.path).toBe('/post');
@@ -140,7 +142,7 @@ describe('Rest', function() {
     it('Should create body (as json).', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.create('posts', body)
+      injectTest.apiEndpoint.create('posts', settings.body)
         .then(y => {
           expect(y.method).toBe('POST');
           expect(y.path).toBe('/posts');
@@ -167,18 +169,19 @@ describe('Rest', function() {
     it('Should post body (as urlencoded).', function(done) {
       let injectTest = container.get(InjectTest);
 
-      injectTest.apiEndpoint.post('posts', body, options)
+      injectTest.apiEndpoint.post('posts', settings.body, settings.optionsForm)
         .then(y => {
           expect(JSON.stringify(y.body)).toBe(JSON.stringify(y.body));
           expect(y.method).toBe('POST');
           expect(y.path).toBe('/posts');
-          expect(y.contentType).toMatch(options.headers['Content-Type']);
+          expect(y.contentType).toMatch(settings.optionsForm.headers['Content-Type']);
           done();
         });
     });
 
     it('Should post body (as FormData) and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.formEndpoint.clientAdapter.defaults = null;
 
       let data = new FormData();
       data.append('message', 'some');

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -25,13 +25,10 @@ describe('Rest', function() {
       expect(injectTest.apiEndpoint instanceof Rest).toBe(true);
       expect(injectTest.githubEndpoint instanceof Rest).toBe(true);
       expect(injectTest.testEndpoint instanceof Rest).toBe(true);
-      expect(injectTest.newEndpoint instanceof Rest).toBe(true);
 
       expect(injectTest.apiEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
       expect(injectTest.githubEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
       expect(injectTest.testEndpoint.clientAdapter instanceof TestClientAdapter).toBe(true);
-      expect(injectTest.newEndpoint.clientAdapter instanceof FetchClientAdapter).toBe(true);
-      expect(injectTest.newEndpoint.clientAdapter.defaults.options).toBe('any');
 
       Promise.all([
         injectTest.githubEndpoint.find('repos/spoonx/aurelia-orm/contributors')

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,2 +1,5 @@
+import {initialize} from 'aurelia-pal-browser';
 import 'aurelia-polyfills';
 import 'fetch';
+
+initialize();


### PR DESCRIPTION
replaces https://github.com/SpoonX/aurelia-api/pull/99

Proposal to wrap clients in adapters:
* clients like fetch are wrapped in adapters which map Rest.request to the appropriate methods of the different clients
* no fancy DI stuff needed since we don't use singletons anyways
* this allows using aurelias http / jsonp client
* further clients are storage client to assess the browsers storage using aurelia-api and a file client to load json files from the project folders
* more client adapters can easily be added as not much more than implementing the new client adapter with a request method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/101)
<!-- Reviewable:end -->
