### PR TITLE
fix(rest): maintain trailing slash to resource parameter

### DIFF
--- a/doc/api_rest.md
+++ b/doc/api_rest.md
@@ -26,6 +26,7 @@ import {Rest} from 'aurelia-api';
 
 All methods will:
 
+* maintain trailing slashes of the resource parameter 
 * stringify the body, if it is an object and the `Content-Type` is set to `application/json` (the default).
 * convert the body to querystring format, if the body is an object and the `Content-Type` is set to any other value.
 * leave the body unchanged, if the `Content-Type` is not set or when the body is not an object.

--- a/src/rest.js
+++ b/src/rest.js
@@ -136,7 +136,11 @@ export class Rest {
 }
 
 function getRequestPath(resource, criteria) {
+  let [, path, trailingSlash] = resource.match(/(.+[^\/])(\/?)$/);
+
   return (criteria !== undefined && criteria !== null
-    ? resource + (typeof criteria !== 'object' ? `/${criteria}` : '?' + buildQueryString(criteria))
+    ? path + (typeof criteria !== 'object'
+            ? `/${criteria}${trailingSlash}`
+            : `${trailingSlash}?${buildQueryString(criteria)}`)
     : resource);
 }

--- a/src/rest.js
+++ b/src/rest.js
@@ -136,11 +136,14 @@ export class Rest {
 }
 
 function getRequestPath(resource, criteria) {
-  let [, path, trailingSlash] = resource.match(/(.+[^\/])(\/?)$/);
+  if (typeof criteria === 'object' && criteria !== null) {
+    resource += `?${buildQueryString(criteria)}`;
+  } else if (criteria) {
+    if (resource.slice(-1) === '/') {
+      criteria += '/';
+    }
+    resource += `/${criteria}`;
+  }
 
-  return (criteria !== undefined && criteria !== null
-    ? path + (typeof criteria !== 'object'
-            ? `/${criteria}${trailingSlash}`
-            : `${trailingSlash}?${buildQueryString(criteria)}`)
-    : resource);
+  return resource.replace(/\/\//g, '/');
 }

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -91,6 +91,13 @@ describe('Rest', function() {
           expect(y.contentType).toMatch('application/json');
           done();
         });
+        
+      injectTest.apiEndpoint.update('posts/', null, body)
+        .then(y => {
+          expect(y.method).toBe('PUT');
+          expect(y.path).toBe('/posts/');
+          done();
+        });
     });
 
     it('Should update with body (as json), criteria and options.', function(done) {
@@ -106,6 +113,14 @@ describe('Rest', function() {
           expect(y.Authorization).toBe(options.headers['Authorization']);
           done();
         });
+
+      injectTest.apiEndpoint.update('posts/', criteria, body, options)
+        .then(y => {
+          expect(y.path).toBe('/posts/');
+          expect(y.query.user).toBe(criteria.user);
+          expect(y.query.comment).toBe(criteria.comment);
+          done();
+        });
     });
   });
 
@@ -118,6 +133,12 @@ describe('Rest', function() {
           expect(y.method).toBe('PATCH');
           expect(y.path).toBe('/post');
           expect(y.contentType).toMatch('application/json');
+          done();
+        });
+
+      injectTest.apiEndpoint.patch('post/', null, body)
+        .then(y => {
+          expect(y.path).toBe('/post/');
           done();
         });
     });
@@ -135,6 +156,14 @@ describe('Rest', function() {
           expect(y.Authorization).toBe(options.headers['Authorization']);
           done();
         });
+
+      injectTest.apiEndpoint.patch('post/', criteria, body, options)
+        .then(y => {
+          expect(y.path).toBe('/post/');
+          expect(y.query.user).toBe(criteria.user);
+          expect(y.query.comment).toBe(criteria.comment);
+          done();
+        });
     });
   });
 
@@ -150,6 +179,12 @@ describe('Rest', function() {
           expect(y.Authorization).toBe(options.headers['Authorization']);
           done();
         });
+      injectTest.apiEndpoint.destroy('posts/', 'id', options)
+        .then(y => {
+          expect(y.path).toBe('/posts/id/');
+          expect(JSON.stringify(y.query)).toBe('{}');
+          done();
+        });
     });
   });
 
@@ -162,6 +197,12 @@ describe('Rest', function() {
           expect(y.method).toBe('POST');
           expect(y.path).toBe('/posts');
           expect(y.contentType).toMatch('application/json');
+          done();
+        });
+
+      injectTest.apiEndpoint.create('posts/', body)
+        .then(y => {
+          expect(y.path).toBe('/posts/');
           done();
         });
     });
@@ -193,6 +234,13 @@ describe('Rest', function() {
           expect(y.Authorization).toBe(options.headers['Authorization']);
           done();
         });
+
+      injectTest.apiEndpoint.post('posts/', body, options)
+        .then(y => {
+          expect(JSON.stringify(y.body)).toBe(JSON.stringify(y.body));
+          expect(y.path).toBe('/posts/');
+          done();
+        });
     });
 
     it('Should post body (as FormData) and options.', function(done) {
@@ -207,6 +255,14 @@ describe('Rest', function() {
           expect(y.path).toBe('/uploads');
           expect(y.contentType).toMatch('multipart/form-data');
           expect(y.Authorization).toBe('Bearer aToken');
+          expect(y.body.message).toBe('some');
+          done();
+        });
+
+      injectTest.formEndpoint.post('uploads/', data, {headers: {'Authorization': 'Bearer aToken'}})
+        .then(y => {
+          expect(y.path).toBe('/uploads/');
+          expect(y.contentType).toMatch('multipart/form-data');
           expect(y.body.message).toBe('some');
           done();
         });

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -39,19 +39,32 @@ describe('Rest', function() {
         injectTest.apiEndpoint.find('posts')
           .then(y => {
             expect(y.method).toBe('GET');
-          }),
-        injectTest.apiEndpoint.find('posts')
-          .then(y => {
             expect(y.path).toBe('/posts');
+          }),
+        injectTest.apiEndpoint.find('posts/')
+          .then(y => {
+            expect(y.method).toBe('GET');
+            expect(y.path).toBe('/posts/');
           }),
         injectTest.apiEndpoint.find('posts', 'id')
           .then(y => {
             expect(y.path).toBe('/posts/id');
             expect(JSON.stringify(y.query)).toBe('{}');
           }),
+        injectTest.apiEndpoint.find('posts/', 'id')
+          .then(y => {
+            expect(y.path).toBe('/posts/id/');
+            expect(JSON.stringify(y.query)).toBe('{}');
+          }),
         injectTest.apiEndpoint.find('posts', criteria)
           .then(y => {
             expect(y.path).toBe('/posts');
+            expect(y.query.user).toBe(criteria.user);
+            expect(y.query.comment).toBe(criteria.comment);
+          }),
+        injectTest.apiEndpoint.find('posts/', criteria)
+          .then(y => {
+            expect(y.path).toBe('/posts/');
             expect(y.query.user).toBe(criteria.user);
             expect(y.query.comment).toBe(criteria.comment);
           }),

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -91,7 +91,7 @@ describe('Rest', function() {
           expect(y.contentType).toMatch('application/json');
           done();
         });
-        
+
       injectTest.apiEndpoint.update('posts/', null, body)
         .then(y => {
           expect(y.method).toBe('PUT');


### PR DESCRIPTION
eg:
apiEndpoint.find('posts/') -> path = http://endpoint/posts/
apiEndpoint.find('posts/', 'id')) -> path = http://endpoint/posts/id/
apiEndpoint.find('posts/', {user:1}) -> path = http://endpoint/posts/?user=1

closing https://github.com/SpoonX/aurelia-api/issues/140

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/141)
<!-- Reviewable:end -->
