### PR TITLE
feat(rest): toString objects without keys before buildQueryString

### DIFF
--- a/src/rest.js
+++ b/src/rest.js
@@ -224,10 +224,32 @@ function getRequestPath(resource: string, idOrCriteria: string|Number|{}, criter
   }
 
   if (typeof criteria === 'object' && criteria !== null) {
-    resource += `?${buildQueryString(criteria)}`;
+    resource += `?${buildQueryString(copyAndTransform(criteria))}`;
   } else if (criteria) {
     resource += `${hasSlash ? '' : '/'}${criteria}${hasSlash ? '/' : ''}`;
   }
 
   return resource;
+}
+
+function copyAndTransform(obj) {
+  let res = {};
+  let keys = Object.keys(obj);
+
+  for (let i = 0; i < keys.length; ++i) {
+    let k = keys[i];
+    let v = obj[k];
+
+    if (typeof v === 'object') {
+      if (Object.keys(v).length === 0) {
+        v = v.toString();
+      } else {
+        v = copyAndTransform(v);
+      }
+    }
+
+    res[k] = v;
+  }
+
+  return res;
 }

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -121,6 +121,32 @@ describe('Rest', function() {
     });
   });
 
+  describe('.find()', function() {
+    it('Should find with criteria using date objects.', function(done) {
+      let injectTest = container.get(InjectTest);
+      let dateCriteria = { date: new Date() };
+
+      injectTest.apiEndpoint.findOne('posts', 'id', dateCriteria)
+        .then(y => {
+          expect(y.method).toBe('GET');
+          expect(y.path).toBe('/posts/id');
+          expect(y.query.date).toBe(dateCriteria.date.toString());
+        }).then(done);
+    });
+
+    it('Should find with criteria using number objects.', function(done) {
+      let injectTest = container.get(InjectTest);
+      let numCriteria = { num: Number(-1.01) };
+
+      injectTest.apiEndpoint.findOne('posts/', 'id', numCriteria)
+        .then(y => {
+          expect(y.method).toBe('GET');
+          expect(y.path).toBe('/posts/id/');
+          expect(y.query.num).toBe(numCriteria.num.toString());
+        }).then(done);
+    });
+  });
+
   describe('.update()', function() {
     it('Should update with body (as json).', function(done) {
       let injectTest = container.get(InjectTest);


### PR DESCRIPTION
this allows eg Date to be used in criteria

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/157)
<!-- Reviewable:end -->
