### PR TITLE
feat(config): Add defaultBaseUrl configuration for endpoints

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -19,6 +19,14 @@ export class Config {
    */
   defaultEndpoint: Rest = null;
 
+
+   /**
+    * Current default baseUrl if set
+    *
+    * @ param {string|null} defaultBaseUrl The Rest client
+    */
+  defaultBaseUrl: string = null;
+
   /**
    * Register a new endpoint.
    *
@@ -47,7 +55,15 @@ export class Config {
     }
 
     // Base url is self / current host.
-    if (typeof configureMethod !== 'string') {
+    if (typeof configureMethod !== 'string' && !this.defaultBaseUrl) {
+      return this;
+    }
+
+    if (this.defaultBaseUrl && typeof configureMethod !== 'string' && typeof configureMethod !== 'function') {
+      newClient.configure(configure => {
+        configure.withBaseUrl(this.defaultBaseUrl);
+      });
+
       return this;
     }
 
@@ -95,6 +111,20 @@ export class Config {
    */
   setDefaultEndpoint(name: string): Config {
     this.defaultEndpoint = this.getEndpoint(name);
+
+    return this;
+  }
+
+  /**
+   * Set a base url for all endpoints
+   *
+   * @param {string} baseUrl The url for endpoints to append
+   *
+   * @return {Config}
+   * @chainable
+   */
+  setDefaultBaseUrl(baseUrl: string): Config {
+    this.defaultBaseUrl = baseUrl;
 
     return this;
   }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -92,6 +92,18 @@ describe('Config', function() {
       expect(config.getEndpoint() instanceof Rest).toBe(true);
     });
   });
+
+  describe('.setDefaultBaseUrl()', function() {
+    it('Should set the default baseUrl.', function() {
+      let config = new Config;
+
+      config.registerEndpoint('api', baseUrls.github);
+      expect(config.endpoints.api.client.baseUrl).toEqual(baseUrls.github);
+      config.setDefaultBaseUrl(baseUrls.api);
+      config.registerEndpoint('api');
+      expect(config.endpoints.api.client.baseUrl).toEqual(baseUrls.api);
+    });
+  });
 });
 
 let baseUrls = {


### PR DESCRIPTION
Able to define a defaultBaseUrl to use for new endpoints, adds the feature in #158. 

`config.setDefaultBaseUrl(baseUrl);`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/159)
<!-- Reviewable:end -->
