### PR TITLE
Add setDefaultBaseUrl() config info

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -45,6 +45,9 @@ aurelia.use
       .registerEndpoint('auth', 'https://auth.myapi.org/')
       .setDefaultEndpoint('auth');
   });
+  
+  // 8: Set Default BaseUrl
+    config.setDefaultBaseUrl('https://myapi.org/');
 ```
 
 Here's a more detailed explanation for every method of registering used:
@@ -78,3 +81,7 @@ This method allows you to set the default endpoint to use. This means, that when
 ## 7: Chain
 
 All methods return `this`, allowing you to chain the calls.
+
+## 8: Set default base URL
+
+All endpoints registered after this call will have the passed in URL prepended by default, rather than the current host. 

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -84,4 +84,4 @@ All methods return `this`, allowing you to chain the calls.
 
 ## 8: Set default base URL
 
-All endpoints registered after this call will have the passed in URL prepended by default, rather than the current host. 
+All endpoints registered after this call will use this default base URL, rather than the current host URL. 


### PR DESCRIPTION
It could be wise to change the order to demonstrate how setDefaultBaseUrl() will not change the baseUrl for endpoints registered prior to calling this function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/160)
<!-- Reviewable:end -->
