### PR TITLE
feat(rest): add a flag to enable RFC6570 uri templates

### DIFF
--- a/config.js
+++ b/config.js
@@ -10,7 +10,7 @@ System.config({
     "aurelia-dependency-injection": "npm:aurelia-dependency-injection@1.0.0",
     "aurelia-fetch-client": "npm:aurelia-fetch-client@1.0.0-rc.1.0.1",
     "aurelia-framework": "npm:aurelia-framework@1.0.1",
-    "aurelia-path": "npm:aurelia-path@1.0.0",
+    "aurelia-path": "npm:aurelia-path@1.1.1",
     "aurelia-polyfills": "npm:aurelia-polyfills@1.0.0",
     "extend": "npm:extend@3.0.0",
     "fetch": "github:github/fetch@1.0.0",
@@ -31,13 +31,13 @@ System.config({
       "aurelia-logging": "npm:aurelia-logging@1.0.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0",
       "aurelia-pal": "npm:aurelia-pal@1.0.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0",
+      "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0",
       "aurelia-templating": "npm:aurelia-templating@1.0.0"
     },
     "npm:aurelia-loader@1.0.0": {
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0"
+      "aurelia-path": "npm:aurelia-path@1.1.1"
     },
     "npm:aurelia-metadata@1.0.0": {
       "aurelia-pal": "npm:aurelia-pal@1.0.0"
@@ -55,7 +55,7 @@ System.config({
       "aurelia-logging": "npm:aurelia-logging@1.0.0",
       "aurelia-metadata": "npm:aurelia-metadata@1.0.0",
       "aurelia-pal": "npm:aurelia-pal@1.0.0",
-      "aurelia-path": "npm:aurelia-path@1.0.0",
+      "aurelia-path": "npm:aurelia-path@1.1.1",
       "aurelia-task-queue": "npm:aurelia-task-queue@1.0.0"
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-fetch-client": "^1.0.0",
       "aurelia-framework": "^1.0.0",
-      "aurelia-path": "^1.0.0",
+      "aurelia-path": "^1.1.1",
       "extend": "^3.0.0"
     },
     "peerDependencies": {
       "aurelia-dependency-injection": "^1.0.0",
       "aurelia-fetch-client": "^1.0.0",
       "aurelia-framework": "^1.0.0",
-      "aurelia-path": "^1.0.0",
+      "aurelia-path": "^1.1.1",
       "extend": "^3.0.0"
     },
     "devDependencies": {
@@ -57,7 +57,7 @@
     "aurelia-dependency-injection": "^1.0.0",
     "aurelia-fetch-client": "^1.0.0",
     "aurelia-framework": "^1.0.0",
-    "aurelia-path": "^1.0.0",
+    "aurelia-path": "^1.1.1",
     "extend": "^3.0.0"
   },
   "devDependencies": {

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,10 @@
 import {HttpClient} from 'aurelia-fetch-client';
 import {Rest} from './rest';
 
+interface RestOptions {
+  useTraditionalUriTemplates?: boolean;
+}
+
 /**
  * Config class. Configures and stores endpoints
  */
@@ -32,13 +36,13 @@ export class Config {
    * @param {string}          name              The name of the new endpoint.
    * @param {Function|string} [configureMethod] Endpoint url or configure method for client.configure().
    * @param {{}}              [defaults]        New defaults for the HttpClient
-   * @param {{}}              [restOptions]     Options to pass when constructing the Rest instance.
+   * @param {RestOptions}     [restOptions]     Options to pass when constructing the Rest instance.
    *
    * @see http://aurelia.io/docs.html#/aurelia/fetch-client/latest/doc/api/class/HttpClientConfiguration
    * @return {Config} this Fluent interface
    * @chainable
    */
-  registerEndpoint(name: string, configureMethod?: string|Function, defaults?: {}, restOptions?: {useTraditionalUriTemplates?: boolean}): Config {
+  registerEndpoint(name: string, configureMethod?: string|Function, defaults?: {}, restOptions?: RestOptions): Config {
     let newClient = new HttpClient();
     let useTraditionalUriTemplates;
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,17 @@
 import {HttpClient} from 'aurelia-fetch-client';
 import {Rest} from './rest';
 
+/**
+ * Represents the options to use when constructing a `Rest` instance.
+ */
 interface RestOptions {
+  /**
+   * `true` to use the traditional URI template standard (RFC6570) when building
+   * query strings from criteria objects, `false` otherwise. Default is `false`.
+   * NOTE: maps to `useTraditionalUriTemplates` parameter on `Rest` constructor.
+   * 
+   * @type {boolean}
+   */
   useTraditionalUriTemplates?: boolean;
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -32,15 +32,20 @@ export class Config {
    * @param {string}          name              The name of the new endpoint.
    * @param {Function|string} [configureMethod] Endpoint url or configure method for client.configure().
    * @param {{}}              [defaults]        New defaults for the HttpClient
+   * @param {{}}              [restOptions]     Options to pass when constructing the Rest instance.
    *
    * @see http://aurelia.io/docs.html#/aurelia/fetch-client/latest/doc/api/class/HttpClientConfiguration
    * @return {Config} this Fluent interface
    * @chainable
    */
-  registerEndpoint(name: string, configureMethod?: string|Function, defaults?: {}): Config {
+  registerEndpoint(name: string, configureMethod?: string|Function, defaults?: {}, restOptions?: {useTraditionalUriTemplates?: boolean}): Config {
     let newClient = new HttpClient();
+    let useTraditionalUriTemplates;
 
-    this.endpoints[name] = new Rest(newClient, name);
+    if (restOptions !== undefined) {
+      useTraditionalUriTemplates = restOptions.useTraditionalUriTemplates;
+    }
+    this.endpoints[name] = new Rest(newClient, name, useTraditionalUriTemplates);
 
     // set custom defaults to Rest
     if (defaults !== undefined) {

--- a/src/rest.js
+++ b/src/rest.js
@@ -34,14 +34,27 @@ export class Rest {
   endpoint: string;
 
   /**
+   * true to use the traditional URI template standard (RFC6570) when building
+   * query strings from criteria objects, false otherwise. Default is false.
+   *
+   * @param {boolean} useTraditionalUriTemplates The flag that enables RFC6570 URI templates.
+   */
+  useTraditionalUriTemplates: boolean;
+
+  /**
    * Inject the httpClient to use for requests.
    *
-   * @param {HttpClient} httpClient The httpClient to use
-   * @param {string}     endpoint   The endpoint name
+   * @param {HttpClient} httpClient                    The httpClient to use
+   * @param {string}     endpoint                      The endpoint name
+   * @param {boolean}    [useTraditionalUriTemplates]  true to use the traditional URI
+   *                                                   template standard (RFC6570) when building
+   *                                                   query strings from criteria objects, false
+   *                                                   otherwise. Default is false.
    */
-  constructor(httpClient: HttpClient, endpoint: string) {
+  constructor(httpClient: HttpClient, endpoint: string, useTraditionalUriTemplates?: boolean) {
     this.client   = httpClient;
     this.endpoint = endpoint;
+    this.useTraditionalUriTemplates = !!useTraditionalUriTemplates;
   }
 
   /**
@@ -83,7 +96,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   find(resource: string, criteria?: {}|string|number, options?: {}): Promise<any|Error> {
-    return this.request('GET', getRequestPath(resource, criteria), undefined, options);
+    return this.request('GET', getRequestPath(resource, this.useTraditionalUriTemplates, criteria), undefined, options);
   }
 
   /**
@@ -97,7 +110,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   findOne(resource: string, id: string|number, criteria?: {}, options?: {}): Promise<any|Error> {
-    return this.request('GET', getRequestPath(resource, id, criteria), undefined, options);
+    return this.request('GET', getRequestPath(resource, this.useTraditionalUriTemplates, id, criteria), undefined, options);
   }
 
   /**
@@ -124,7 +137,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   update(resource: string, criteria?: {}|string|number, body?: {}, options?: {}): Promise<any|Error> {
-    return this.request('PUT', getRequestPath(resource, criteria), body, options);
+    return this.request('PUT', getRequestPath(resource, this.useTraditionalUriTemplates, criteria), body, options);
   }
 
   /**
@@ -139,7 +152,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   updateOne(resource: string, id: string|number, criteria?: {}, body?: {}, options?: {}): Promise<any|Error> {
-    return this.request('PUT', getRequestPath(resource, id, criteria), body, options);
+    return this.request('PUT', getRequestPath(resource, this.useTraditionalUriTemplates, id, criteria), body, options);
   }
 
   /**
@@ -153,7 +166,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   patch(resource: string, criteria?: {}|string|number, body?: {}, options?: {}): Promise<any|Error> {
-    return this.request('PATCH', getRequestPath(resource, criteria), body, options);
+    return this.request('PATCH', getRequestPath(resource, this.useTraditionalUriTemplates, criteria), body, options);
   }
 
   /**
@@ -168,7 +181,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   patchOne(resource: string, id: string|number, criteria?: {}, body?: {}, options?: {}): Promise<any|Error> {
-    return this.request('PATCH', getRequestPath(resource, id, criteria), body, options);
+    return this.request('PATCH', getRequestPath(resource, this.useTraditionalUriTemplates, id, criteria), body, options);
   }
 
   /**
@@ -181,7 +194,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   destroy(resource: string, criteria?: {}|string|number, options?: {}): Promise<any|Error> {
-    return this.request('DELETE', getRequestPath(resource, criteria), undefined, options);
+    return this.request('DELETE', getRequestPath(resource, this.useTraditionalUriTemplates, criteria), undefined, options);
   }
 
   /**
@@ -195,7 +208,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   destroyOne(resource: string, id: string|number, criteria?: {}, options?: {}): Promise<any|Error> {
-    return this.request('DELETE', getRequestPath(resource, id, criteria), undefined, options);
+    return this.request('DELETE', getRequestPath(resource, this.useTraditionalUriTemplates, id, criteria), undefined, options);
   }
 
   /**
@@ -216,11 +229,12 @@ export class Rest {
  * getRequestPath
  *
  * @param {string} resource
+ * @param {boolean} traditional
  * @param {(string|number|{})} [idOrCriteria]
  * @param {{}} [criteria]
  * @returns {string}
  */
-function getRequestPath(resource: string, idOrCriteria?: string|number|{}, criteria?: {}) {
+function getRequestPath(resource: string, traditional: boolean, idOrCriteria?: string|number|{}, criteria?: {}) {
   let hasSlash = resource.slice(-1) === '/';
 
   if (typeof idOrCriteria === 'string' || typeof idOrCriteria === 'number') {
@@ -230,7 +244,7 @@ function getRequestPath(resource: string, idOrCriteria?: string|number|{}, crite
   }
 
   if (typeof criteria === 'object' && criteria !== null) {
-    resource += `?${buildQueryString(criteria)}`;
+    resource += `?${buildQueryString(criteria, traditional)}`;
   } else if (criteria) {
     resource += `${hasSlash ? '' : '/'}${criteria}${hasSlash ? '/' : ''}`;
   }

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -15,6 +15,7 @@ config.registerEndpoint('jsonplaceholder', baseUrls.jsonplaceholder);
 config.registerEndpoint('form', baseUrls.api, null);
 
 let criteria = {user: 'john', comment: 'last'};
+let criteriaWithArray = {sort: ['first', 'last']};
 let body = {message: 'some'};
 let options = {
   headers: {
@@ -27,6 +28,7 @@ describe('Rest', function() {
   describe('.find()', function() {
     it('Should find results for multiple endpoints.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       expect(injectTest.apiEndpoint instanceof Rest).toBe(true);
       expect(injectTest.jsonplaceholderEndpoint instanceof Rest).toBe(true);
@@ -85,16 +87,38 @@ describe('Rest', function() {
             expect(y.path).toBe('/posts');
             expect(y.contentType).toBe(options.headers['Content-Type']);
             expect(y.Authorization).toBe(options.headers['Authorization']);
+          }),
+        injectTest.apiEndpoint.find('posts', criteriaWithArray)
+          .then(y => {
+            expect(y.path).toBe('/posts');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/posts?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+    it('Should find with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.find('posts', criteriaWithArray)
+          .then(y => {
+            expect(y.path).toBe('/posts');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/posts?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`)
+          })
+      ]).then(x => done());
     });
   });
 
   describe('.findOne()', function() {
     it('Should find with id, criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.findOne('posts', 'id', criteria, options)
@@ -114,10 +138,33 @@ describe('Rest', function() {
             expect(y.query.comment).toBe(criteria.comment);
             expect(y.contentType).toMatch(options.headers['Content-Type']);
             expect(y.Authorization).toBe(options.headers['Authorization']);
+          }),
+        injectTest.apiEndpoint.findOne('posts/', 'id', criteriaWithArray)
+          .then(y => {
+            expect(y.method).toBe('GET');
+            expect(y.path).toBe('/posts/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/posts/id/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+    it('Should findOne with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.findOne('posts/', 'id', criteriaWithArray)
+          .then(y => {
+            expect(y.method).toBe('GET');
+            expect(y.path).toBe('/posts/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/posts/id/?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`);
+          })
+      ]).then(x => done());
     });
   });
 
@@ -144,6 +191,7 @@ describe('Rest', function() {
 
     it('Should update with body (as json), criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.update('posts', criteria, body, options)
@@ -160,16 +208,39 @@ describe('Rest', function() {
             expect(y.path).toBe('/posts/');
             expect(y.query.user).toBe(criteria.user);
             expect(y.query.comment).toBe(criteria.comment);
+          }),
+        injectTest.apiEndpoint.update('posts/', criteriaWithArray, body, options)
+          .then(y => {
+            expect(y.path).toBe('/posts/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/posts/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+
+    it('Should update with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.update('posts/', criteriaWithArray, body, options)
+          .then(y => {
+            expect(y.path).toBe('/posts/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/posts/?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`);
+          })
+      ]).then(x => done());
     });
   });
 
   describe('.updateOne()', function() {
     it('Should update with body (as json), criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.updateOne('posts', 'id', criteria, body, options)
@@ -189,16 +260,41 @@ describe('Rest', function() {
             expect(y.query.comment).toBe(criteria.comment);
             expect(y.contentType).toMatch(options.headers['Content-Type']);
             expect(y.Authorization).toBe(options.headers['Authorization']);
+          }),
+        injectTest.apiEndpoint.updateOne('posts/', 'id', criteriaWithArray, body)
+          .then(y => {
+            expect(y.method).toBe('PUT');
+            expect(y.path).toBe('/posts/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/posts/id/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+
+    it('Should updateOne with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.updateOne('posts/', 'id', criteriaWithArray, body)
+          .then(y => {
+            expect(y.method).toBe('PUT');
+            expect(y.path).toBe('/posts/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/posts/id/?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`);
+          })
+      ]).then(x => done());
     });
   });
 
   describe('.patch()', function() {
     it('Should patch with body (as json).', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.patch('post', null, body)
@@ -210,6 +306,13 @@ describe('Rest', function() {
         injectTest.apiEndpoint.patch('post/', null, body)
           .then(y => {
             expect(y.path).toBe('/post/');
+          }),
+        injectTest.apiEndpoint.patch('post/', criteriaWithArray, body)
+          .then(y => {
+            expect(y.path).toBe('/post/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/post/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
@@ -218,6 +321,7 @@ describe('Rest', function() {
 
     it('Should patch with body (as json), criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.patch('post', criteria, body, options)
@@ -237,16 +341,41 @@ describe('Rest', function() {
             expect(y.query.comment).toBe(criteria.comment);
             expect(y.contentType).toMatch(options.headers['Content-Type']);
             expect(y.Authorization).toBe(options.headers['Authorization']);
+          }),
+        injectTest.apiEndpoint.patch('post/', criteriaWithArray, body)
+          .then(y => {
+            expect(y.method).toBe('PATCH');
+            expect(y.path).toBe('/post/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/post/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+
+    it('Should patch with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.patch('post/', criteriaWithArray, body)
+          .then(y => {
+            expect(y.method).toBe('PATCH');
+            expect(y.path).toBe('/post/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/post/?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`);
+          })
+      ]).then(x => done());
     });
   });
 
   describe('.patchOne()', function() {
     it('Should patch with body (as json), id, criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.patchOne('post', 'id', criteria, body, options)
@@ -266,16 +395,41 @@ describe('Rest', function() {
             expect(y.query.comment).toBe(criteria.comment);
             expect(y.contentType).toMatch(options.headers['Content-Type']);
             expect(y.Authorization).toBe(options.headers['Authorization']);
+          }),
+        injectTest.apiEndpoint.patchOne('post/', 'id', criteriaWithArray, body)
+          .then(y => {
+            expect(y.method).toBe('PATCH');
+            expect(y.path).toBe('/post/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/post/id/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+
+    it('Should patchOne with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.patchOne('post/', 'id', criteriaWithArray, body)
+          .then(y => {
+            expect(y.method).toBe('PATCH');
+            expect(y.path).toBe('/post/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/post/id/?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`);
+          })
+      ]).then(x => done());
     });
   });
 
   describe('.destroy()', function() {
     it('Should destroy with criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.destroy('posts', criteria, options)
@@ -293,16 +447,41 @@ describe('Rest', function() {
             expect(y.query.user).toBe(criteria.user);
             expect(y.query.comment).toBe(criteria.comment);
             expect(y.Authorization).toBe(options.headers['Authorization']);
+          }),
+        injectTest.apiEndpoint.destroy('posts/', criteriaWithArray)
+          .then(y => {
+            expect(y.method).toBe('DELETE');
+            expect(y.path).toBe('/posts/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/posts/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+
+    it('Should destroy with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.destroy('posts/', criteriaWithArray)
+          .then(y => {
+            expect(y.method).toBe('DELETE');
+            expect(y.path).toBe('/posts/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/posts/?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`);
+          })
+      ]).then(x => done());
     });
   });
 
   describe('.destroyOne()', function() {
     it('Should destroy with id, criteria and options.', function(done) {
       let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = false;
 
       Promise.all([
         injectTest.apiEndpoint.destroyOne('posts', 'id', criteria, options)
@@ -320,10 +499,34 @@ describe('Rest', function() {
             expect(y.query.user).toBe(criteria.user);
             expect(y.query.comment).toBe(criteria.comment);
             expect(y.Authorization).toBe(options.headers['Authorization']);
+          }),
+        injectTest.apiEndpoint.destroyOne('posts/', 'id', criteriaWithArray)
+          .then(y => {
+            expect(y.method).toBe('DELETE');
+            expect(y.path).toBe('/posts/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(encodeURI(`/posts/id/?sort[]=${criteriaWithArray.sort[0]}&sort[]=${criteriaWithArray.sort[1]}`));
           })
       ]).then(x => {
         done();
       });
+    });
+
+    it('Should destroyOne with RFC6570 queries.', function(done) {
+      let injectTest = container.get(InjectTest);
+      injectTest.apiEndpoint.useTraditionalUriTemplates = true;
+
+      Promise.all([
+        injectTest.apiEndpoint.destroyOne('posts/', 'id', criteriaWithArray)
+          .then(y => {
+            expect(y.method).toBe('DELETE');
+            expect(y.path).toBe('/posts/id/');
+            expect(y.query.sort[0]).toBe(criteriaWithArray.sort[0]);
+            expect(y.query.sort[1]).toBe(criteriaWithArray.sort[1]);
+            expect(y.originalUrl).toBe(`/posts/id/?sort=${criteriaWithArray.sort[0]}&sort=${criteriaWithArray.sort[1]}`);
+          })
+      ]).then(x => done());
     });
   });
 


### PR DESCRIPTION
Resolves #174 by adding a `useTraditionalUriTemplates` boolean property to the `Rest` class

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/175)

<!-- Reviewable:end -->
