### PR TITLE
Transfer defaults from the endpoint client configuration function to the endpoint defaults

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,8 +29,14 @@ aurelia.use
 
     // 3: With different endpoint defaults
     config.registerEndpoint('weather', 'https://weatherapi.io/', {headers: {x: 'foo'}});
+    // or
+    config.registerEndpoint('weather', configure => {
+      configure
+        .withBaseUrl('https://weatherapi.io/')
+        .withDefaults({headers: {x: 'foo'}});
+      }));
 
-    // 4: Without endpoint defaults
+    // 4: Without endpoint defaults. Use this for FormData
     config.registerEndpoint('weather', 'https://weatherapi.io/', null);
 
     // 5: Own configuration
@@ -91,7 +97,7 @@ This method allows you to specify different defaults to use for your endpoint, i
 
 ## 4: With no defaults
 
-This method allows you to remove the defaults to use for your endpoint.
+This method allows you to remove the defaults to use for your endpoint. This is needed for "multipart/form-data" requests as the content type will be set automatically if the transmitted body is of the type FormData.
 
 ## 5: Own configuration
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,9 @@ var app = require('./node_modules/spoonx-tools/build-plugin/tasks/server').app;
 var multer  = require('multer')
 var storage = multer.memoryStorage()
 var upload  = multer({storage: storage})
+var bodyParser = require('body-parser');
+
+app.use(bodyParser.json({ type: 'application/vnd.api+json' }))
 
 app.post('/uploads', upload.single(), function(req, res) {
   res.send({

--- a/src/config.js
+++ b/src/config.js
@@ -70,6 +70,11 @@ export class Config {
     if (typeof configureMethod === 'function') {
       newClient.configure(configureMethod);
 
+      // transfer user defaults from http-client to endpoint
+      if (typeof newClient.defaults === 'object' && newClient.defaults !== null) {
+        this.endpoints[name].defaults = newClient.defaults;
+      }
+
       return this;
     }
 

--- a/src/rest.js
+++ b/src/rest.js
@@ -71,8 +71,9 @@ export class Rest {
     let requestOptions = extend(true, {headers: {}}, this.defaults, options || {}, {method, body});
     let contentType    = requestOptions.headers['Content-Type'] || requestOptions.headers['content-type'];
 
+    // if body is object, stringify to json or urlencoded depending on content-type
     if (typeof body === 'object' && body !== null && contentType) {
-      requestOptions.body = (/^application\/json/).test(contentType.toLowerCase())
+      requestOptions.body = (/^application\/(.+\+)?json/).test(contentType.toLowerCase())
                           ? JSON.stringify(body)
                           : buildQueryString(body);
     }

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -4,13 +4,13 @@ import {Rest} from '../src/rest';
 
 describe('Config', function() {
   describe('.registerEndpoint()', function() {
-    it('Should properly register an endpoint when providing a config callback.', function() {
+    it('Should properly register an endpoint when providing a config callback transferring client defaults.', function() {
       let config   = new Config;
       let returned = config.registerEndpoint('github', function(configure) {
         configure.withBaseUrl(baseUrls.github);
         configure.withDefaults(userOptions);
       });
-      expect(config.endpoints.github.defaults).toEqual(defaultOptions);
+      expect(config.endpoints.github.defaults).toEqual(userOptions);
       expect(config.endpoints.github.client.defaults).toEqual(userOptions);
       expect(config.endpoints.github.client.baseUrl).toEqual(baseUrls.github);
       expect(returned).toBe(config);

--- a/test/resources/inject-test.js
+++ b/test/resources/inject-test.js
@@ -1,11 +1,12 @@
 import {inject} from 'aurelia-dependency-injection';
 import {Endpoint} from '../../src/endpoint';
 
-@inject(Endpoint.of('api'), Endpoint.of('jsonplaceholder'), Endpoint.of('form'))
+@inject(Endpoint.of('api'), Endpoint.of('jsonplaceholder'), Endpoint.of('form'), Endpoint.of('urlencoded'))
 export class InjectTest {
-  constructor(apiEndpoint, jsonplaceholderEndpoint, formEndpoint) {
+  constructor(apiEndpoint, jsonplaceholderEndpoint, formEndpoint, urlencodedEndpoint) {
     this.apiEndpoint    = apiEndpoint;
     this.jsonplaceholderEndpoint = jsonplaceholderEndpoint;
     this.formEndpoint = formEndpoint;
-  }
+    this.urlencodedEndpoint = urlencodedEndpoint;
+   }
 }

--- a/test/resources/inject-test.js
+++ b/test/resources/inject-test.js
@@ -1,12 +1,13 @@
 import {inject} from 'aurelia-dependency-injection';
 import {Endpoint} from '../../src/endpoint';
 
-@inject(Endpoint.of('api'), Endpoint.of('jsonplaceholder'), Endpoint.of('form'), Endpoint.of('urlencoded'))
+@inject(Endpoint.of('api'), Endpoint.of('jsonplaceholder'), Endpoint.of('form'), Endpoint.of('urlencoded'), Endpoint.of('fetchConfig'))
 export class InjectTest {
-  constructor(apiEndpoint, jsonplaceholderEndpoint, formEndpoint, urlencodedEndpoint) {
+  constructor(apiEndpoint, jsonplaceholderEndpoint, formEndpoint, urlencodedEndpoint, fetchConfigEndpoint) {
     this.apiEndpoint    = apiEndpoint;
     this.jsonplaceholderEndpoint = jsonplaceholderEndpoint;
     this.formEndpoint = formEndpoint;
     this.urlencodedEndpoint = urlencodedEndpoint;
+    this.fetchConfigEndpoint = fetchConfigEndpoint;
    }
 }

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -2,6 +2,7 @@ import {Config} from '../src/config';
 import {Rest} from '../src/rest';
 import {Container} from 'aurelia-dependency-injection';
 import {InjectTest} from './resources/inject-test';
+import {buildQueryString} from 'aurelia-path';
 
 let container = new Container();
 let config    = container.get(Config);
@@ -9,20 +10,22 @@ let baseUrls  = {
   jsonplaceholder: 'http://jsonplaceholder.typicode.com/',
   api            : 'http://127.0.0.1:1927/'
 };
+let options = {
+  headers: {
+    'Content-Type' : 'application/x-www-form-urlencoded',
+    'Authorization': 'Bearer aToken'
+  }
+};
 
 config.registerEndpoint('api', baseUrls.api);
 config.registerEndpoint('jsonplaceholder', baseUrls.jsonplaceholder);
 config.registerEndpoint('form', baseUrls.api, null);
+config.registerEndpoint('urlencoded', baseUrls.api, options);
 
 let criteria = {user: 'john', comment: 'last'};
 let criteriaWithArray = {sort: ['first', 'last']};
 let body = {message: 'some'};
-let options = {
-  headers: {
-    'Content-Type': 'application/x-www-form-urlencoded',
-    'Authorization': 'Bearer aToken'
-  }
-};
+
 
 describe('Rest', function() {
   describe('.find()', function() {
@@ -575,13 +578,13 @@ describe('Rest', function() {
   });
 
   describe('.post()', function() {
-    it('Should post body (as urlencoded).', function(done) {
+    it('Should post body (as urlencoded) with custom header (x-www-form-urlencoded).', function(done) {
       let injectTest = container.get(InjectTest);
 
       Promise.all([
         injectTest.apiEndpoint.post('posts', body, options)
           .then(y => {
-            expect(JSON.stringify(y.body)).toBe(JSON.stringify(y.body));
+            expect(JSON.stringify(y.body)).toBe(JSON.stringify(body));
             expect(y.method).toBe('POST');
             expect(y.path).toBe('/posts');
             expect(y.contentType).toMatch(options.headers['Content-Type']);
@@ -589,8 +592,58 @@ describe('Rest', function() {
           }),
         injectTest.apiEndpoint.post('posts/', body, options)
           .then(y => {
-            expect(JSON.stringify(y.body)).toBe(JSON.stringify(y.body));
+            expect(JSON.stringify(y.body)).toBe(JSON.stringify(body));
             expect(y.path).toBe('/posts/');
+          })
+      ]).then(x => {
+        done();
+      });
+    });
+
+    it('Should post object body (as urlencoded) with registered default header (x-www-form-urlencoded).', function(done) {
+      let injectTest = container.get(InjectTest);
+      let responseOutput = {
+        response: null
+      };
+
+      Promise.all([
+        injectTest.urlencodedEndpoint.post('posts', body)
+          .then(y => {
+            expect(y.method).toBe('POST');
+            expect(y.path).toBe('/posts');
+            expect(y.contentType).toMatch(options.headers['Content-Type']);
+            expect(y.Authorization).toBe(options.headers['Authorization']);
+            expect(y.body.message).toBe('some');
+          }),
+        injectTest.urlencodedEndpoint.post('posts/', body)
+          .then(y => {
+            expect(y.path).toBe('/posts/');
+            expect(y.body.message).toBe('some');
+          })
+      ]).then(x => {
+        done();
+      });
+    });
+
+    it('Should post string body as string with registered default header (x-www-form-urlencoded).', function(done) {
+      let injectTest = container.get(InjectTest);
+      let responseOutput = {
+        response: null
+      };
+
+      Promise.all([
+        injectTest.urlencodedEndpoint.post('posts', buildQueryString(body))
+          .then(y => {
+            expect(y.method).toBe('POST');
+            expect(y.path).toBe('/posts');
+            expect(y.contentType).toMatch(options.headers['Content-Type']);
+            expect(y.Authorization).toBe(options.headers['Authorization']);
+            expect(y.body.message).toBe('some');
+          }),
+        injectTest.urlencodedEndpoint.post('posts/', buildQueryString(body))
+          .then(y => {
+            expect(y.path).toBe('/posts/');
+            expect(y.body.message).toBe('some');
           })
       ]).then(x => {
         done();

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -16,16 +16,26 @@ let options = {
     'Authorization': 'Bearer aToken'
   }
 };
+let jsonOptions = {
+  headers: {
+    'Content-Type': 'application/vnd.api+json',
+    'Accept': 'application/vnd.api+json'
+  }
+};
 
 config.registerEndpoint('api', baseUrls.api);
 config.registerEndpoint('jsonplaceholder', baseUrls.jsonplaceholder);
 config.registerEndpoint('form', baseUrls.api, null);
 config.registerEndpoint('urlencoded', baseUrls.api, options);
+config.registerEndpoint('fetchConfig', fetchConfig => {
+  fetchConfig
+    .withBaseUrl(baseUrls.api)
+    .withDefaults(jsonOptions);
+  });
 
 let criteria = {user: 'john', comment: 'last'};
 let criteriaWithArray = {sort: ['first', 'last']};
 let body = {message: 'some'};
-
 
 describe('Rest', function() {
   describe('.find()', function() {
@@ -641,6 +651,54 @@ describe('Rest', function() {
             expect(y.body.message).toBe('some');
           }),
         injectTest.urlencodedEndpoint.post('posts/', buildQueryString(body))
+          .then(y => {
+            expect(y.path).toBe('/posts/');
+            expect(y.body.message).toBe('some');
+          })
+      ]).then(x => {
+        done();
+      });
+    });
+
+    it('Should post object body (as json) with fetchConfig configuration.', function(done) {
+      let injectTest = container.get(InjectTest);
+      let responseOutput = {
+        response: null
+      };
+
+      Promise.all([
+        injectTest.fetchConfigEndpoint.post('posts', body)
+          .then(y => {
+            expect(y.method).toBe('POST');
+            expect(y.path).toBe('/posts');
+            expect(y.contentType).toBe(jsonOptions.headers['Content-Type']);
+            expect(y.body.message).toBe('some');
+          }),
+        injectTest.fetchConfigEndpoint.post('posts/', body)
+          .then(y => {
+            expect(y.path).toBe('/posts/');
+            expect(y.body.message).toBe('some');
+          })
+      ]).then(x => {
+        done();
+      });
+    });
+
+    it('Should post string body as string with fetchConfig configuration.', function(done) {
+      let injectTest = container.get(InjectTest);
+      let responseOutput = {
+        response: null
+      };
+
+      Promise.all([
+        injectTest.fetchConfigEndpoint.post('posts', JSON.stringify(body))
+          .then(y => {
+            expect(y.method).toBe('POST');
+            expect(y.path).toBe('/posts');
+            expect(y.contentType).toBe(jsonOptions.headers['Content-Type']);
+            expect(y.body.message).toBe('some');
+          }),
+        injectTest.fetchConfigEndpoint.post('posts/', JSON.stringify(body))
           .then(y => {
             expect(y.path).toBe('/posts/');
             expect(y.body.message).toBe('some');


### PR DESCRIPTION
fixes #195 

the relevant change is only https://github.com/SpoonX/aurelia-api/pull/209/files#diff-9d9a6cd82f41984872a66a3ab0d440c4

the only addition is recognizing application/vnd.api+json as json for convinience

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/209)
<!-- Reviewable:end -->
