### PR TITLE
Return non json responses

### DIFF
--- a/doc/Quick start.md
+++ b/doc/Quick start.md
@@ -103,20 +103,20 @@ You probably don't only want to retrieve data but send some also. The Rest clien
 
 ````js
 endpoint
-  .client                                                           // the httpClient instance
-  .endpoint                                                         // name of the endpoint
-  .default                                                          // The fetch client defaults
-  .find(resource, criteria, options, responseOutput)                // GET
-  .findOne(resource, id, criteria, options, responseOutput)         // GET
-  .post(resource, body, options, responseOutput) {                  // POST
-  .update(resource, criteria, body, options, responseOutput)        // PUT
-  .updateOne(resource, id, criteria, body, options, responseOutput) // PUT
-  .patch(resource, criteria, body, options, responseOutput)         // PATCH
-  .patchOne(resource, id, criteria, body, options, responseOutput)  // PATCH
-  .destroy(resource, criteria, options, responseOutput)             // DELETE
-  .destroyOne(resource, id, criteria, options, responseOutput)      // DELETE
-  .create(resource, body, options, responseOutput)                  // POST
-  .request(method, path, body, options, responseOutput)             // method
+  .client                                           // the httpClient instance
+  .endpoint                                         // name of the endpoint
+  .default                                          // The fetch client defaults
+  .find(resource, criteria, options)                // GET
+  .findOne(resource, id, criteria, options)         // GET
+  .post(resource, body, options) {                  // POST
+  .update(resource, criteria, body, options)        // PUT
+  .updateOne(resource, id, criteria, body, options) // PUT
+  .patch(resource, criteria, body, options)         // PATCH
+  .patchOne(resource, id, criteria, body, options)  // PATCH
+  .destroy(resource, criteria, options)             // DELETE
+  .destroyOne(resource, id, criteria, options)      // DELETE
+  .create(resource, body, options)                  // POST
+  .request(method, path, body, options)             // method
 ```
 
 The [Rest api](api_rest.md) has more information about those. Here is just another quick example:

--- a/doc/README.md
+++ b/doc/README.md
@@ -137,20 +137,20 @@ All methods return on success a Promise with the server response parsed to an ob
 
 ```js
 endpoint
-  .client                                                           // the httpClient instance
-  .endpoint                                                         // name of the endpoint
-  .default                                                          // The fetch client defaults
-  .find(resource, idOrCriteria, options, responseOutput)            // GET
-  .findOne(resource, id, criteria, options, responseOutput)         // GET
-  .post(resource, body, options, responseOutput) {                  // POST
-  .update(resource, idOrCriteria, body, options, responseOutput)    // PUT
-  .updateOne(resource, id, criteria, body, options, responseOutput) // PUT
-  .patch(resource, idOrCriteria, body, options, responseOutput)     // PATCH
-  .patchOne(resource, id, criteria, body, options, responseOutput)  // PATCH
-  .destroy(resource, idOrCriteria, options, responseOutput)         // DELETE
-  .destroyOne(resource, id, criteria, options, responseOutput)      // DELETE
-  .create(resource, body, options, responseOutput)                  // POST
-  .request(method, path, body, options, responseOutput)             // method
+  .client                                           // the httpClient instance
+  .endpoint                                         // name of the endpoint
+  .default                                          // The fetch client defaults
+  .find(resource, idOrCriteria, options)            // GET
+  .findOne(resource, id, criteria, options)         // GET
+  .post(resource, body, options)                    // POST
+  .update(resource, idOrCriteria, body, options)    // PUT
+  .updateOne(resource, id, criteria, body, options) // PUT
+  .patch(resource, idOrCriteria, body, options)     // PATCH
+  .patchOne(resource, id, criteria, body, options)  // PATCH
+  .destroy(resource, idOrCriteria, options)         // DELETE
+  .destroyOne(resource, id, criteria, options)      // DELETE
+  .create(resource, body, options)                  // POST
+  .request(method, path, body, options)             // method
 ```
 
 ## Note

--- a/doc/README.md
+++ b/doc/README.md
@@ -133,21 +133,21 @@ All methods will:
 * leave the body unchanged, if the `Content-Type` is not set or when the body is not an object.
 * maintain trailing slashes of the resource parameter
 
-All methods return on success a Promise with the server response parsed to an object if possible. On error, they reject with the server response. If possible and parseError is set true, they reject with the JSON parsed server response.
+All methods return on success a Promise with the server response parsed to an object if possible. On error, they reject with the server response. If possible and parseError is set true, they reject with the JSON parsed server response. For anything else but JSON response, pass one a responseOutput object and the original response will be added to responseOutput.response.
 
 ```js
 endpoint
   .client                                                           // the httpClient instance
   .endpoint                                                         // name of the endpoint
   .default                                                          // The fetch client defaults
-  .find(resource, idOrCriteria, options, responseOutput)                // GET
+  .find(resource, idOrCriteria, options, responseOutput)            // GET
   .findOne(resource, id, criteria, options, responseOutput)         // GET
   .post(resource, body, options, responseOutput) {                  // POST
-  .update(resource, idOrCriteria, body, options, responseOutput)        // PUT
+  .update(resource, idOrCriteria, body, options, responseOutput)    // PUT
   .updateOne(resource, id, criteria, body, options, responseOutput) // PUT
-  .patch(resource, idOrCriteria, body, options, responseOutput)         // PATCH
+  .patch(resource, idOrCriteria, body, options, responseOutput)     // PATCH
   .patchOne(resource, id, criteria, body, options, responseOutput)  // PATCH
-  .destroy(resource, idOrCriteria, options, responseOutput)             // DELETE
+  .destroy(resource, idOrCriteria, options, responseOutput)         // DELETE
   .destroyOne(resource, id, criteria, options, responseOutput)      // DELETE
   .create(resource, body, options, responseOutput)                  // POST
   .request(method, path, body, options, responseOutput)             // method

--- a/doc/api_rest.md
+++ b/doc/api_rest.md
@@ -37,20 +37,21 @@ All methods will:
 * leave the body unchanged, if the `Content-Type` is not set or when the body is not an object.
 * maintain trailing slashes of the resource parameter
 
-All methods return a Promise with the server response parsed to an object if possible.
+All methods return a Promise with the server response JSON parsed to an object if possible. To retrieve any type other that json responses, use the responseOutput option.
 
-### .request(method, path[, body][, options])
+### .request(method, path[, body][, options][,responseOutput])
 
 Perform a request to the server.
 
 #### Parameters
 
-| Parameter | Type   | Description                                 |
-| --------- | ------ | ------------------------------------------- |
-| method    | string | Request method. POST, GET, DELETE, PUT etc. |
-| path      | string | Path to make the request to.                |
-| body      | object | The body (when permitted by method).        |
-| options   | object | Additional options for the fetch            |
+| Parameter      | Type   | Description                                 |
+| -------------- | ------ | ------------------------------------------- |
+| method         | string | Request method. POST, GET, DELETE, PUT etc. |
+| path           | string | Path to make the request to.                |
+| body           | object | The body (when permitted by method).        |
+| options        | object | Additional options for the fetch            |
+| responseOutput | object | If provided, responseOutput.response contains a clone of the original response |
 
 #### Returns
 
@@ -76,10 +77,29 @@ export class MyViewModel {
 }
 ```
 
+Here's an example of an xml response.
+
+```javascript
+import {Rest} from 'aurelia-api';
+
+@inject(Rest)
+export class MyViewModel {
+  constructor (restClient) {
+    let requestOutput = {};
+    restClient.request('GET', 'api/users-xml', null, headers: {
+          'Accept': 'application/xml'
+        }, requestOutput)
+      .then(_=>requestOutput.response.text())
+      .then(console.log)
+      .catch(console.error);
+  }
+}
+```
+
 ----------
 
-### .find(resource, idOrCriteria[, options])
-### .findOne(resource, id, criteria[, options])
+### .find(resource, idOrCriteria[, options][,responseOutput])
+### .findOne(resource, id, criteria[, options][,responseOutput])
 
 Find one or multiple resources. (GET request)
 
@@ -91,6 +111,7 @@ Find one or multiple resources. (GET request)
 | id        | string/number  | A specific ID.                                 |
 | criteria  | object         | Object of supported filters.                   |
 | options   | object         | Additional options for the fetch               |
+| responseOutput | object    | If provided, responseOutput.response contains a clone of the original response |
 
 #### Returns
 
@@ -118,13 +139,13 @@ export class MyViewModel {
 
 ----------
 
-### .create(resource, body[, options])
+### .create(resource, body[, options][,responseOutput])
 
 A convenience method (naming) that does exactly the same as `.post()`.
 
 ----------
 
-### .post(resource, body[, options])
+### .post(resource, body[, options][,responseOutput])
 
 Send a POST request to supplied `resource`.
 
@@ -135,6 +156,7 @@ Send a POST request to supplied `resource`.
 | resource  | string | The name of the resource you wish to post to. |
 | body      | object | The body to post.                             |
 | options   | object | Additional options for the fetch              |
+| responseOutput | object | If provided, responseOutput.response contains a clone of the original response |
 
 #### Returns
 
@@ -163,8 +185,8 @@ export class MyViewModel {
 
 ----------
 
-### .update(resource, idOrCriteria, body[, options])
-### .updateOne(resource, id, criteria, body[, options])
+### .update(resource, idOrCriteria, body[, options][,responseOutput])
+### .updateOne(resource, id, criteria, body[, options][,responseOutput])
 
 Send a PUT request to supplied `resource`.
 
@@ -177,6 +199,7 @@ Send a PUT request to supplied `resource`.
 | criteria  | object         | Object of supported filters.                   |
 | body      | object         | The new values for the records.                |
 | options   | object         | Additional options for the fetch               |
+| responseOutput | object | If provided, responseOutput.response contains a clone of the original response |
 
 #### Returns
 
@@ -201,8 +224,8 @@ export class MyViewModel {
 
 ----------
 
-### .patch(resource, idOrCriteria, body[, options])
-### .patchOne(resource, id, criteria, body[, options])
+### .patch(resource, idOrCriteria, body[, options][,responseOutput])
+### .patchOne(resource, id, criteria, body[, options][,responseOutput])
 
 Send a PATCH request to supplied `resource`.
 
@@ -215,6 +238,7 @@ Send a PATCH request to supplied `resource`.
 | criteria  | object         | Object of supported filters.                   |
 | body      | object         | The new values for the records.                |
 | options   | object         | Additional options for the fetch               |
+| responseOutput | object | If provided, responseOutput.response contains a clone of the original response |
 
 #### Returns
 
@@ -239,8 +263,8 @@ export class MyViewModel {
 
 ----------
 
-### .destroy(resource, idOrCriteria[, options])
-### .destroyOne(resource, id, criteria[, options])
+### .destroy(resource, idOrCriteria[, options][,responseOutput])
+### .destroyOne(resource, id, criteria[, options][,responseOutput])
 
 Delete one or multiple resources. (DELETE request)
 
@@ -252,6 +276,7 @@ Delete one or multiple resources. (DELETE request)
 | id        | string/number  | A specific ID.                                 |
 | criteria  | object         | Object of supported filters.                   |
 | options   | object         | Additional options for the fetch               |
+| responseOutput | object | If provided, responseOutput.response contains a clone of the original response |
 
 #### Returns
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,18 @@ var bodyParser = require('body-parser');
 
 app.use(bodyParser.json({ type: 'application/vnd.api+json' }))
 
+var xmlResponse= `
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <verzeichnis>
+        <titel>Wikipedia Städteverzeichnis</titel>
+    </verzeichnis>
+  `;
+
+app.get('/xml', function(req, res) {
+  res.type('application/xml');
+  res.send(xmlResponse);
+});
+
 app.post('/uploads', upload.single(), function(req, res) {
   res.send({
     path         : req.path,

--- a/src/rest.js
+++ b/src/rest.js
@@ -64,17 +64,18 @@ export class Rest {
    * @param {string}                path       Path to the resource
    * @param {{}}                    [body]     The body to send if applicable
    * @param {{}}                    [options]  Fetch request options overwrites
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   request(method: string, path: string, body?: {}, options?: {}, responseOutput?: { response: Response}): Promise<any|Error> {
     let requestOptions = extend(true, {headers: {}}, this.defaults, options || {}, {method, body});
     let contentType    = requestOptions.headers['Content-Type'] || requestOptions.headers['content-type'];
+    let accept         = requestOptions.headers['Accept'] || requestOptions.headers['accept'];
+    const appJson = /^application\/(.+\+)?json/;
 
     // if body is object, stringify to json or urlencoded depending on content-type
     if (typeof body === 'object' && body !== null && contentType) {
-      requestOptions.body = (/^application\/(.+\+)?json/).test(contentType.toLowerCase())
+      requestOptions.body = appJson.test(contentType.toLowerCase())
                           ? JSON.stringify(body)
                           : buildQueryString(body);
     }
@@ -82,10 +83,13 @@ export class Rest {
     return this.client.fetch(path, requestOptions).then((response: Response) => {
       if (response.status >= 200 && response.status < 400) {
         if (responseOutput) {
+          console.warn(`The responseOutput option is deprecated. The original response returned, if the header 'Accept' isn't the default 'application/json'.`);
           responseOutput.response = response.clone();
         }
 
-        return response.json().catch(() => null);
+        return accept && appJson.test(accept.toLowerCase())
+              ? response.json().catch(() => null)
+              : response;
       }
 
       throw response;
@@ -98,7 +102,6 @@ export class Rest {
    * @param {string}                    resource  Resource to find in
    * @param {string|number|{}}          idOrCriteria  Object for where clause, string / number for id.
    * @param {{}}                        [options] Extra request options.
-   * @param {{ response: Response}}     [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -113,7 +116,6 @@ export class Rest {
    * @param {string|number}    id          String / number for id to be added to the path.
    * @param {{}}               [criteria]  Object for where clause
    * @param {{}}               [options]   Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -127,7 +129,6 @@ export class Rest {
    * @param {string}                resource  Resource to create
    * @param {{}}                    [body]    The data to post (as Object)
    * @param {{}}                    [options] Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -142,7 +143,6 @@ export class Rest {
    * @param {string|number|{}}      idOrCriteria  Object for where clause, string / number for id.
    * @param {{}}                    [body]    New data for provided idOrCriteria.
    * @param {{}}                    [options] Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -158,7 +158,6 @@ export class Rest {
    * @param {{}}                    [criteria] Object for where clause
    * @param {{}}                    [body]     New data for provided criteria.
    * @param {{}}                    [options]  Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -173,7 +172,6 @@ export class Rest {
    * @param {string|number|{}}      [idOrCriteria] Object for where clause, string / number for id.
    * @param {{}}                    [body]     Data to patch for provided idOrCriteria.
    * @param {{}}                    [options]  Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -189,7 +187,6 @@ export class Rest {
    * @param {{}}                    [criteria] Object for where clause
    * @param {{}}                    [body]     Data to patch for provided criteria.
    * @param {{}}                    [options]  Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -203,7 +200,6 @@ export class Rest {
    * @param {string}                resource   The resource to delete
    * @param {string|number|{}}      [idOrCriteria] Object for where clause, string / number for id.
    * @param {{}}                    [options]  Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -218,7 +214,6 @@ export class Rest {
    * @param {string|number}         id         String / number for id to be added to the path.
    * @param {{}}                    [criteria] Object for where clause
    * @param {{}}                    [options]  Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -232,7 +227,6 @@ export class Rest {
    * @param {string}                resource  The resource to create
    * @param {{}}                    [body]    The data to post (as Object)
    * @param {{}}                    [options] Extra request options.
-   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>} Server response as Object
    */

--- a/src/rest.js
+++ b/src/rest.js
@@ -60,11 +60,11 @@ export class Rest {
   /**
    * Make a request to the server.
    *
-   * @param {string}          method     The fetch method
-   * @param {string}          path       Path to the resource
-   * @param {{}}              [body]     The body to send if applicable
-   * @param {{}}              [options]  Fetch request options overwrites
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                method     The fetch method
+   * @param {string}                path       Path to the resource
+   * @param {{}}                    [body]     The body to send if applicable
+   * @param {{}}                    [options]  Fetch request options overwrites
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -82,7 +82,7 @@ export class Rest {
     return this.client.fetch(path, requestOptions).then((response: Response) => {
       if (response.status >= 200 && response.status < 400) {
         if (responseOutput) {
-          responseOutput.response = response;
+          responseOutput.response = response.clone();
         }
 
         return response.json().catch(() => null);
@@ -98,7 +98,7 @@ export class Rest {
    * @param {string}                    resource  Resource to find in
    * @param {string|number|{}}          idOrCriteria  Object for where clause, string / number for id.
    * @param {{}}                        [options] Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {{ response: Response}}     [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -124,10 +124,10 @@ export class Rest {
   /**
    * Create a new instance for resource.
    *
-   * @param {string}           resource  Resource to create
-   * @param {{}}               [body]    The data to post (as Object)
-   * @param {{}}               [options] Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource  Resource to create
+   * @param {{}}                    [body]    The data to post (as Object)
+   * @param {{}}                    [options] Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -138,11 +138,11 @@ export class Rest {
   /**
    * Update a resource.
    *
-   * @param {string}           resource  Resource to update
-   * @param {string|number|{}} idOrCriteria  Object for where clause, string / number for id.
-   * @param {{}}               [body]    New data for provided idOrCriteria.
-   * @param {{}}               [options] Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource  Resource to update
+   * @param {string|number|{}}      idOrCriteria  Object for where clause, string / number for id.
+   * @param {{}}                    [body]    New data for provided idOrCriteria.
+   * @param {{}}                    [options] Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -153,12 +153,12 @@ export class Rest {
   /**
    * Update a resource.
    *
-   * @param {string}           resource   Resource to update
-   * @param {string|number}    id         String / number for id to be added to the path.
-   * @param {{}}               [criteria] Object for where clause
-   * @param {{}}               [body]     New data for provided criteria.
-   * @param {{}}               [options]  Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource   Resource to update
+   * @param {string|number}         id         String / number for id to be added to the path.
+   * @param {{}}                    [criteria] Object for where clause
+   * @param {{}}                    [body]     New data for provided criteria.
+   * @param {{}}                    [options]  Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -169,11 +169,11 @@ export class Rest {
   /**
    * Patch a resource.
   *
-   * @param {string}           resource   Resource to patch
-   * @param {string|number|{}} [idOrCriteria] Object for where clause, string / number for id.
-   * @param {{}}               [body]     Data to patch for provided idOrCriteria.
-   * @param {{}}               [options]  Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource   Resource to patch
+   * @param {string|number|{}}      [idOrCriteria] Object for where clause, string / number for id.
+   * @param {{}}                    [body]     Data to patch for provided idOrCriteria.
+   * @param {{}}                    [options]  Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -184,12 +184,12 @@ export class Rest {
   /**
    * Patch a resource.
    *
-   * @param {string}           resource   Resource to patch
-   * @param {string|number}    id         String / number for id to be added to the path.
-   * @param {{}}               [criteria] Object for where clause
-   * @param {{}}               [body]     Data to patch for provided criteria.
-   * @param {{}}               [options]  Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource   Resource to patch
+   * @param {string|number}         id         String / number for id to be added to the path.
+   * @param {{}}                    [criteria] Object for where clause
+   * @param {{}}                    [body]     Data to patch for provided criteria.
+   * @param {{}}                    [options]  Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -200,10 +200,10 @@ export class Rest {
   /**
    * Delete a resource.
    *
-   * @param {string}           resource   The resource to delete
-   * @param {string|number|{}} [idOrCriteria] Object for where clause, string / number for id.
-   * @param {{}}               [options]  Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource   The resource to delete
+   * @param {string|number|{}}      [idOrCriteria] Object for where clause, string / number for id.
+   * @param {{}}                    [options]  Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -214,11 +214,11 @@ export class Rest {
   /**
    * Delete a resource.
    *
-   * @param {string}           resource   The resource to delete
-   * @param {string|number}    id         String / number for id to be added to the path.
-   * @param {{}}               [criteria] Object for where clause
-   * @param {{}}               [options]  Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource   The resource to delete
+   * @param {string|number}         id         String / number for id to be added to the path.
+   * @param {{}}                    [criteria] Object for where clause
+   * @param {{}}                    [options]  Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
@@ -229,10 +229,10 @@ export class Rest {
   /**
    * Create a new instance for resource.
    *
-   * @param {string}           resource  The resource to create
-   * @param {{}}               [body]    The data to post (as Object)
-   * @param {{}}               [options] Extra request options.
-   * @param {{ response: Response}}              [responseOutput]  reference output for Response object
+   * @param {string}                resource  The resource to create
+   * @param {{}}                    [body]    The data to post (as Object)
+   * @param {{}}                    [options] Extra request options.
+   * @param {{ response: Response}} [responseOutput]  reference output for Response object
    *
    * @return {Promise<*>} Server response as Object
    */

--- a/test/resources/inject-test.js
+++ b/test/resources/inject-test.js
@@ -1,26 +1,25 @@
 import {inject} from 'aurelia-dependency-injection';
 import {Endpoint} from '../../src/endpoint';
 
-@inject(Endpoint.of('api'),
+@inject(
+  Endpoint.of('api'),
   Endpoint.of('jsonplaceholder'),
   Endpoint.of('form'),
   Endpoint.of('urlencoded'),
-  Endpoint.of('fetchConfig'),
-  Endpoint.of('xml')
+  Endpoint.of('fetchConfig')
 )
 export class InjectTest {
-  constructor(apiEndpoint,
+  constructor(
+    apiEndpoint,
     jsonplaceholderEndpoint,
     formEndpoint,
     urlencodedEndpoint,
-    fetchConfigEndpoint,
-    xmlEndpoint
+    fetchConfigEndpoint
   ) {
-    this.apiEndpoint    = apiEndpoint;
+    this.apiEndpoint             = apiEndpoint;
     this.jsonplaceholderEndpoint = jsonplaceholderEndpoint;
-    this.formEndpoint = formEndpoint;
-    this.urlencodedEndpoint = urlencodedEndpoint;
-    this.fetchConfigEndpoint = fetchConfigEndpoint;
-    this.xmlEndpoint = xmlEndpoint;
+    this.formEndpoint            = formEndpoint;
+    this.urlencodedEndpoint      = urlencodedEndpoint;
+    this.fetchConfigEndpoint     = fetchConfigEndpoint;
    }
 }

--- a/test/resources/inject-test.js
+++ b/test/resources/inject-test.js
@@ -1,13 +1,26 @@
 import {inject} from 'aurelia-dependency-injection';
 import {Endpoint} from '../../src/endpoint';
 
-@inject(Endpoint.of('api'), Endpoint.of('jsonplaceholder'), Endpoint.of('form'), Endpoint.of('urlencoded'), Endpoint.of('fetchConfig'))
+@inject(Endpoint.of('api'),
+  Endpoint.of('jsonplaceholder'),
+  Endpoint.of('form'),
+  Endpoint.of('urlencoded'),
+  Endpoint.of('fetchConfig'),
+  Endpoint.of('xml')
+)
 export class InjectTest {
-  constructor(apiEndpoint, jsonplaceholderEndpoint, formEndpoint, urlencodedEndpoint, fetchConfigEndpoint) {
+  constructor(apiEndpoint,
+    jsonplaceholderEndpoint,
+    formEndpoint,
+    urlencodedEndpoint,
+    fetchConfigEndpoint,
+    xmlEndpoint
+  ) {
     this.apiEndpoint    = apiEndpoint;
     this.jsonplaceholderEndpoint = jsonplaceholderEndpoint;
     this.formEndpoint = formEndpoint;
     this.urlencodedEndpoint = urlencodedEndpoint;
     this.fetchConfigEndpoint = fetchConfigEndpoint;
+    this.xmlEndpoint = xmlEndpoint;
    }
 }

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -14,13 +14,14 @@ let baseUrls  = {
 let options = {
   headers: {
     'Content-Type' : 'application/x-www-form-urlencoded',
+    'Accept'       : 'Application/json',
     'Authorization': 'Bearer aToken'
   }
 };
 let jsonOptions = {
   headers: {
     'Content-Type': 'application/vnd.api+json',
-    'Accept': 'application/vnd.api+json'
+    'Accept'      : 'application/vnd.api+json'
   }
 };
 
@@ -32,7 +33,7 @@ var xmlResponse= `
   `;
 
 config.registerEndpoint('api', baseUrls.api);
-config.registerEndpoint('xml', baseUrls.xml);
+config.registerEndpoint('xml', baseUrls.xml, {headers: {'Content-Type': 'application/xml', 'Accept': 'application/xml'}});
 config.registerEndpoint('jsonplaceholder', baseUrls.jsonplaceholder);
 config.registerEndpoint('form', baseUrls.api, null);
 config.registerEndpoint('urlencoded', baseUrls.api, options);
@@ -212,7 +213,7 @@ describe('Rest', function() {
   describe('.find()', function() {
     it('Should find with id and criteria using date objects.', function(done) {
       let injectTest = container.get(InjectTest);
-      let dateCriteria = { date: new Date() };
+      let dateCriteria = {date: new Date()};
 
       injectTest.apiEndpoint.findOne('posts', 'id', dateCriteria)
         .then(y => {
@@ -225,7 +226,7 @@ describe('Rest', function() {
 
     it('Should find with criteria using id and date objects.', function(done) {
       let injectTest = container.get(InjectTest);
-      let dateCriteria = { id: 'id', date: new Date() };
+      let dateCriteria = {id: 'id', date: new Date()};
 
       injectTest.apiEndpoint.findOne('posts', dateCriteria)
         .then(y => {
@@ -239,7 +240,7 @@ describe('Rest', function() {
 
     it('Should find with criteria using number objects.', function(done) {
       let injectTest = container.get(InjectTest);
-      let numCriteria = { num: Number(-1.01) };
+      let numCriteria = {num: Number(-1.01)};
 
       injectTest.apiEndpoint.findOne('posts/', 'id', numCriteria)
         .then(y => {
@@ -253,7 +254,7 @@ describe('Rest', function() {
   describe('.find()', function() {
     it('Should find with criteria using date objects.', function(done) {
       let injectTest = container.get(InjectTest);
-      let dateCriteria = { date: new Date() };
+      let dateCriteria = {date: new Date()};
 
       injectTest.apiEndpoint.findOne('posts', 'id', dateCriteria)
         .then(y => {
@@ -265,7 +266,7 @@ describe('Rest', function() {
 
     it('Should find with criteria using number objects.', function(done) {
       let injectTest = container.get(InjectTest);
-      let numCriteria = { num: Number(-1.01) };
+      let numCriteria = {num: Number(-1.01)};
 
       injectTest.apiEndpoint.findOne('posts/', 'id', numCriteria)
         .then(y => {
@@ -276,20 +277,26 @@ describe('Rest', function() {
     });
   });
 
-  fdescribe('.find()', function() {
-    fit('Should post body and retrieve xml', function(done) {
+  describe('.find()', function() {
+    it('Should retrieve xml (using responseOutput)', function(done) {
       let injectTest = container.get(InjectTest);
       let responseOutput = {
         response: null
       };
-      let optionsXML = {
-        headers: {
-          'Content-Type': 'application/xml'
-        }
-      };
 
-      injectTest.apiEndpoint.find('xml', null, optionsXML, responseOutput)
+      injectTest.apiEndpoint.find('xml', null, null, responseOutput)
         .then(_ => responseOutput.response.text())
+        .then(xmlText => {
+          expect(xmlText).toBe(xmlResponse);
+         })
+        .then(() => done());
+    });
+
+    it('Should retrieve xml (using accept header)', function(done) {
+      let injectTest = container.get(InjectTest);
+  
+      injectTest.apiEndpoint.find('xml', null, {headers: {'Accept': 'application/xml'}})
+        .then(response => response.text())
         .then(xmlText => {
           expect(xmlText).toBe(xmlResponse);
          })
@@ -776,9 +783,6 @@ describe('Rest', function() {
 
     it('Should post object body (as urlencoded) with registered default header (x-www-form-urlencoded).', function(done) {
       let injectTest = container.get(InjectTest);
-      let responseOutput = {
-        response: null
-      };
 
       Promise.all([
         injectTest.urlencodedEndpoint.post('posts', body)
@@ -801,9 +805,6 @@ describe('Rest', function() {
 
     it('Should post string body as string with registered default header (x-www-form-urlencoded).', function(done) {
       let injectTest = container.get(InjectTest);
-      let responseOutput = {
-        response: null
-      };
 
       Promise.all([
         injectTest.urlencodedEndpoint.post('posts', buildQueryString(body))
@@ -826,9 +827,6 @@ describe('Rest', function() {
 
     it('Should post object body (as json) with fetchConfig configuration.', function(done) {
       let injectTest = container.get(InjectTest);
-      let responseOutput = {
-        response: null
-      };
 
       Promise.all([
         injectTest.fetchConfigEndpoint.post('posts', body)
@@ -850,9 +848,6 @@ describe('Rest', function() {
 
     it('Should post string body as string with fetchConfig configuration.', function(done) {
       let injectTest = container.get(InjectTest);
-      let responseOutput = {
-        response: null
-      };
 
       Promise.all([
         injectTest.fetchConfigEndpoint.post('posts', JSON.stringify(body))
@@ -874,16 +869,12 @@ describe('Rest', function() {
 
     it('Should post body (as FormData) and options.', function(done) {
       let injectTest = container.get(InjectTest);
-      let responseOutput = {
-        response: null
-      };
-
       let data = new FormData();
 
       data.append('message', 'some');
 
       Promise.all([
-        injectTest.formEndpoint.post('uploads', data, {headers: {'Authorization': 'Bearer aToken'}})
+        injectTest.formEndpoint.post('uploads', data, {headers: {'Authorization': 'Bearer aToken', 'Accept': 'application/json'}})
           .then(y => {
             expect(y.method).toBe('POST');
             expect(y.path).toBe('/uploads');
@@ -891,7 +882,7 @@ describe('Rest', function() {
             expect(y.Authorization).toBe('Bearer aToken');
             expect(y.body.message).toBe('some');
           }),
-        injectTest.formEndpoint.post('uploads/', data, {headers: {'Authorization': 'Bearer aToken'}})
+        injectTest.formEndpoint.post('uploads/', data, {headers: {'Authorization': 'Bearer aToken', 'Accept': 'application/json'}})
           .then(y => {
             expect(y.path).toBe('/uploads/');
             expect(y.contentType).toMatch('multipart/form-data');

--- a/test/rest.spec.js
+++ b/test/rest.spec.js
@@ -8,7 +8,8 @@ let container = new Container();
 let config    = container.get(Config);
 let baseUrls  = {
   jsonplaceholder: 'http://jsonplaceholder.typicode.com/',
-  api            : 'http://127.0.0.1:1927/'
+  api            : 'http://127.0.0.1:1927/',
+  xml            : 'http://127.0.0.1:1927/xml',
 };
 let options = {
   headers: {
@@ -23,7 +24,15 @@ let jsonOptions = {
   }
 };
 
+var xmlResponse= `
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+    <verzeichnis>
+        <titel>Wikipedia Städteverzeichnis</titel>
+    </verzeichnis>
+  `;
+
 config.registerEndpoint('api', baseUrls.api);
+config.registerEndpoint('xml', baseUrls.xml);
 config.registerEndpoint('jsonplaceholder', baseUrls.jsonplaceholder);
 config.registerEndpoint('form', baseUrls.api, null);
 config.registerEndpoint('urlencoded', baseUrls.api, options);
@@ -264,6 +273,27 @@ describe('Rest', function() {
           expect(y.path).toBe('/posts/id/');
           expect(y.query.num).toBe(numCriteria.num.toString());
         }).then(done);
+    });
+  });
+
+  fdescribe('.find()', function() {
+    fit('Should post body and retrieve xml', function(done) {
+      let injectTest = container.get(InjectTest);
+      let responseOutput = {
+        response: null
+      };
+      let optionsXML = {
+        headers: {
+          'Content-Type': 'application/xml'
+        }
+      };
+
+      injectTest.apiEndpoint.find('xml', null, optionsXML, responseOutput)
+        .then(_ => responseOutput.response.text())
+        .then(xmlText => {
+          expect(xmlText).toBe(xmlResponse);
+         })
+        .then(() => done());
     });
   });
 
@@ -742,30 +772,7 @@ describe('Rest', function() {
   });
 
   describe('.post()', function() {
-    it('Should post body (as urlencoded) with custom header (x-www-form-urlencoded).', function(done) {
-      let injectTest = container.get(InjectTest);
-      let responseOutput = {
-        response: null
-      };
 
-      Promise.all([
-        injectTest.apiEndpoint.post('posts', body, options)
-          .then(y => {
-            expect(JSON.stringify(y.body)).toBe(JSON.stringify(body));
-            expect(y.method).toBe('POST');
-            expect(y.path).toBe('/posts');
-            expect(y.contentType).toMatch(options.headers['Content-Type']);
-            expect(y.Authorization).toBe(options.headers['Authorization']);
-          }),
-        injectTest.apiEndpoint.post('posts/', body, options)
-          .then(y => {
-            expect(JSON.stringify(y.body)).toBe(JSON.stringify(body));
-            expect(y.path).toBe('/posts/');
-          })
-      ]).then(x => {
-        done();
-      });
-    });
 
     it('Should post object body (as urlencoded) with registered default header (x-www-form-urlencoded).', function(done) {
       let injectTest = container.get(InjectTest);


### PR DESCRIPTION
Currently all responses are consumed mandatory by response.json() resulting in the hack of the responseOutput option. I propose to only consume responses with the default 'application/json' and return other unchanged. 
Would need major version bump

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/218)
<!-- Reviewable:end -->
