### PR TITLE
fix(config): pre-populate defaults before invoking user config function

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -43,7 +43,6 @@ aurelia.use
     config.registerEndpoint('twitter', configure => {
       configure
         .withBaseUrl('https://api.twitter.io/')
-        .withDefaults(null); // use endpoint defaults
         //.withDefaults({headers: {x: 'foo'}}); // uses own defaults
         //.withDefaults(); // no defaults. same as omitting withDefaults()
     });
@@ -56,7 +55,7 @@ aurelia.use
       .registerEndpoint('auth', 'https://auth.myapi.org/')
       .setDefaultEndpoint('auth');
   });
-  
+
   // 8: Set Default BaseUrl
     config.setDefaultBaseUrl('https://myapi.org/');
 ```
@@ -119,4 +118,4 @@ All methods return `this`, allowing you to chain the calls.
 
 ## 8: Set default base URL
 
-All endpoints registered after this call will use this default base URL, rather than the current host URL. 
+All endpoints registered after this call will use this default base URL, rather than the current host URL.

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,4 @@
-import {HttpClient} from 'aurelia-fetch-client';
+import {HttpClient, HttpClientConfiguration} from 'aurelia-fetch-client';
 import {Rest} from './rest';
 
 /**
@@ -68,12 +68,16 @@ export class Config {
 
     // Manual configure of client.
     if (typeof configureMethod === 'function') {
-      newClient.configure(configureMethod);
+      newClient.configure(
+          (newClientConfig: HttpClientConfiguration) => {
+            return configureMethod(
+                newClientConfig.withDefaults(this.endpoints[name].defaults)
+            );
+          }
+      );
 
       // transfer user defaults from http-client to endpoint
-      if (typeof newClient.defaults === 'object' && newClient.defaults !== null) {
-        this.endpoints[name].defaults = newClient.defaults;
-      }
+      this.endpoints[name].defaults = newClient.defaults;
 
       return this;
     }

--- a/src/rest.js
+++ b/src/rest.js
@@ -69,7 +69,7 @@ export class Rest {
    * @return {Promise<*>|Promise<Error>} Server response as Object
    */
   request(method: string, path: string, body?: {}, options?: {}, responseOutput?: { response: Response}): Promise<any|Error> {
-    let requestOptions = extend(true, {headers: {}}, this.defaults, options || {}, {method, body});
+    let requestOptions = extend(true, {headers: {}}, this.defaults || {}, options || {}, {method, body});
     let contentType    = requestOptions.headers['Content-Type'] || requestOptions.headers['content-type'];
 
     // if body is object, stringify to json or urlencoded depending on content-type

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -42,6 +42,29 @@ describe('Config', function() {
       expect(config.endpoints.api.client.baseUrl).toEqual(baseUrls.api);
       expect(returned).toBe(config);
     });
+
+    it('Should properly register an endpoint with standard defaults when config functions are applied.', function() {
+      let config   = new Config;
+      let returned = config.registerEndpoint('api', function(configure) {
+        configure.withBaseUrl(baseUrls.api);
+      });
+
+      expect(config.endpoints.api.defaults).toEqual(defaultOptions);
+      expect(config.endpoints.api.client.baseUrl).toEqual(baseUrls.api);
+      expect(returned).toBe(config);
+    });
+
+    it('Should properly register an endpoint with null defaults when defaults specified as "null".', function() {
+      let config   = new Config;
+      let returned = config.registerEndpoint('api', function(configure) {
+        configure.withBaseUrl(baseUrls.api);
+        configure.withDefaults(null);
+      });
+
+      expect(config.endpoints.api.defaults).toEqual(null);
+      expect(config.endpoints.api.client.baseUrl).toEqual(baseUrls.api);
+      expect(returned).toBe(config);
+    });
   });
 
   describe('.getEndpoint()', function() {


### PR DESCRIPTION
Fixes #222 

~I can't seem to run the tests locally, so let's see if CI can do it.~

I got the tests to run, and added one for explicitly setting defaults to null and not setting defaults at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/spoonx/aurelia-api/223)
<!-- Reviewable:end -->
